### PR TITLE
Fixed install and bad characters in welcome cell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER KBase Developer
 
 RUN apt-get update
 RUN apt-get install -y python-coverage
-RUN pip install --upgrade ndg-httpsclient
+RUN pip install ndg-httpsclient==0.4.2
 # -----------------------------------------
 
 COPY ./ /kb/module

--- a/local_data/welcome-cell-content.md
+++ b/local_data/welcome-cell-content.md
@@ -3,7 +3,7 @@
 
 **What's a Narrative?** Narratives are shareable, reproducible workflows that can include data, analysis steps, results, visualizations and commentary. [Learn more...]({{config.resources.docSite.base.url}}/narrative-guide)
 
-**Take the Tour:** Choose "Narrative Tour" from “hamburger” menu (three small horizontal lines) on the top left. This new feature walks you through the user interface, pointing out various useful aspects of it.
+**Take the Tour:** Choose "Narrative Tour" from "hamburger" menu (three small horizontal lines) on the top left. This new feature walks you through the user interface, pointing out various useful aspects of it.
 
 **Get Some Data:** Click the Add Data button in the Data Panel to search KBase data or upload your own. Mouse over a data object to add it to your Narrative. [Learn more...]({{config.resources.docSite.base.url}}/narrative-guide/explore-data)
 
@@ -15,4 +15,4 @@
 
 **Questions?** [Contact us]({{config.resources.docSite.base.url}}/contact-us)!
 
-Ready to begin adding to your Narrative? You can keep this Welcome cell or delete it by selecting "Delete cell" from the "..." menu in the top right corner of this cell. 
+Ready to begin adding to your Narrative? You can keep this Welcome cell or delete it by selecting "Delete cell" from the "..." menu in the top right corner of this cell.


### PR DESCRIPTION
The install was crashing due to a dependency version conflict, and there were bad, non-ascii quotes in the content cell that wouldn't serialize properly.