### PR TITLE
Updates to expose narrative/narratorial listing methods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,19 @@ MAINTAINER KBase Developer
 # Insert apt-get instructions here to install
 # any required dependencies for your module.
 
-RUN sudo apt-get install python-dev libffi-dev libssl-dev
-RUN pip install cffi --upgrade
-RUN pip install pyopenssl --upgrade
-RUN pip install ndg-httpsclient --upgrade
-RUN pip install pyasn1 --upgrade
-RUN pip install requests --upgrade && \
-    pip install 'requests[security]' --upgrade
-RUN apt-get install -y python-coverage
-RUN pip install ndg-httpsclient==0.4.2
+RUN pip install coverage
+
+# update security libraries in the base image
+RUN pip install cffi --upgrade \
+    && pip install pyopenssl --upgrade \
+    && pip install ndg-httpsclient --upgrade \
+    && pip install pyasn1 --upgrade \
+    && pip install requests --upgrade \
+    && pip install 'requests[security]' --upgrade
+
 # -----------------------------------------
+
+RUN pip install pylru
 
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work

--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -51,6 +51,27 @@ module NarrativeService {
         int wsid, string workspace, string chsum, int size,
         mapping<string, string> meta> object_info;
 
+    /* Information about a workspace.
+    
+        ws_id id - the numerical ID of the workspace.
+        ws_name workspace - name of the workspace.
+        username owner - name of the user who owns (e.g. created) this workspace.
+        timestamp moddate - date when the workspace was last modified.
+        int max_objid - the maximum object ID appearing in this workspace.
+            Since cloning a workspace preserves object IDs, this number may be
+            greater than the number of objects in a newly cloned workspace.
+        permission user_permission - permissions for the authenticated user of
+            this workspace.
+        permission globalread - whether this workspace is globally readable.
+        lock_status lockstat - the status of the workspace lock.
+        usermeta metadata - arbitrary user-supplied metadata about
+            the workspace.
+            
+    */
+    typedef tuple<int id, string workspace, string owner, string moddate,
+        int max_objid, string user_permission, string globalread,
+        string lockstat, mapping<string, string> metadata> workspace_info;
+
     typedef structure {
         list<object_info> set_items_info;
     } SetItems;
@@ -262,4 +283,81 @@ module NarrativeService {
 
     funcdef list_available_types(ListAvailableTypesParams params)
         returns (ListAvailableTypesOutput) authentication required;
+
+
+
+
+    /* ********************************** */
+    /* Listing Narratives / Naratorials (plus Narratorial Management) */
+
+    typedef structure { } ListNarratorialParams;
+
+    /* info for a narratorial */
+    typedef structure {
+        workspace_info ws;
+        object_info nar;
+    } Narratorial;
+
+    typedef structure {
+        list <Narratorial> narratorials;
+    } NarratorialList;
+
+    funcdef list_narratorials(ListNarratorialParams params)
+        returns (NarratorialList) authentication optional;
+
+
+    
+
+    typedef structure {
+        workspace_info ws;
+        object_info nar;
+    } Narrative;
+
+    typedef structure {
+        list <Narrative> narratives;
+    } NarrativeList;
+
+    /* List narratives
+        type parameter indicates which narratives to return.
+        Supported options are for now 'mine' or 'public'  TODO: 'shared'
+    */
+    typedef structure {
+        string type;
+    } ListNarrativeParams;
+
+    funcdef list_narratives(ListNarrativeParams params)
+        returns (NarrativeList) authentication optional;
+
+
+    /*
+        ws field is a string, but properly interpreted whether it is a workspace
+        name or ID
+    */
+    typedef structure {
+        string ws;
+        string description;
+    } SetNarratorialParams;
+
+    typedef structure { } SetNarratorialResult;
+
+    /*
+        Allows a user to create a Narratorial given a WS they own. Right now
+        anyone can do this, but we may restrict in the future to users that
+        have a particular role.  Run simply as:
+            ns.set_narratorial({'ws':'MyWsName'}) or,
+            ns.set_narratorial({'ws':'4231'})
+    */
+    funcdef set_narratorial(SetNarratorialParams params)
+        returns (SetNarratorialResult) authentication required;
+
+    typedef structure {
+        string ws;
+    } RemoveNarratorialParams;
+
+    typedef structure { } RemoveNarratorialResult;
+
+    funcdef remove_narratorial(RemoveNarratorialParams params)
+        returns (RemoveNarratorialResult) authentication required;
+
+
 };

--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -319,7 +319,7 @@ module NarrativeService {
 
     /* List narratives
         type parameter indicates which narratives to return.
-        Supported options are for now 'mine' or 'public'  TODO: 'shared'
+        Supported options are for now 'mine', 'public', or 'shared'
     */
     typedef structure {
         string type;

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -25,3 +25,4 @@ setapi-version = dev
 datapaletteservice-version = dev
 scratch = /kb/module/work/tmp
 intro-markdown-file = /kb/module/local_data/welcome-cell-content.md
+narrative-list-cache-size = 20000

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.3
+    0.0.4
 
 owners:
     [rsutormin, msneddon, wjriehl]

--- a/lib/NarrativeService/NarrativeListUtils.py
+++ b/lib/NarrativeService/NarrativeListUtils.py
@@ -1,0 +1,164 @@
+import pylru
+
+# For reference:
+#   workspace_info:
+#     0 ws_id id
+#     1 ws_name workspace
+#     2 username owner
+#     3 timestamp moddate
+#     4 int max_objid
+#     5 permission user_permission
+#     6 permission globalread
+#     7 lock_status lockstat
+#     8 usermeta metadata
+
+
+class NarrativeInfoCache(object):
+
+    def __init__(self, cache_size):
+        self.cache = pylru.lrucache(int(cache_size))
+
+    def clear_cache(self):
+        self.cache.clear()
+
+    def check_cache_size(self):
+        return len(self.cache)
+
+
+    def get_info_list(self, ws_lookup_table, wsClient):
+        '''
+            Given a set of WS info, lookup the corresponding Narrative
+            information.
+
+            input:
+                ws_lookup_table = dict of ws_id -> workspace_info
+            output:
+                [{
+                    'ws': workspace_info,
+                    'nar': narrative_info
+                 },
+                 ...
+                 ]
+        '''
+        # search the cache and extract what we have, mark what was missed
+        res = self._search_cache(ws_lookup_table)
+        items = res['items']
+        missed_items = res['missed']
+
+        # for objects that were missed, we have to go out and fetch that
+        # narrative object info
+        all_items = items
+        if len(missed_items) > 0:
+            more_items = self._fetch_objects_and_cache(missed_items, ws_lookup_table, wsClient)
+            all_items += more_items
+
+        return all_items
+
+    def _search_cache(self, ws_lookup_table):
+        items = []  # =[{'ws': [...], 'nar': [...]}, ...]
+        missed = []  # =[ws_info1, ws_info2, ... ]
+        for ws_info in ws_lookup_table.itervalues():
+            key = self._get_cache_key(ws_info)
+            if key in self.cache:
+                items.append({'ws': ws_info, 'nar': self.cache[key]})
+            else:
+                missed.append(ws_info)
+        return {'items': items, 'missed': missed}
+
+    def _fetch_objects_and_cache(self, ws_list, full_ws_lookup_table, wsClient):
+        ''' Fetches narrative objects (if possible) for everything in ws_list '''
+        obj_ref_list = []
+        for ws_info in ws_list:
+            if 'narrative' not in ws_info[8]:
+                continue
+            ref = str(ws_info[0]) + '/' + str(ws_info[8]['narrative'])
+            obj_ref_list.append({'ref': ref})
+
+        if len(obj_ref_list) == 0:
+            return []
+
+        get_obj_params = {'objects': obj_ref_list, 'includeMetadata': 1}
+        narrative_list = wsClient.get_object_info3(get_obj_params)['infos']
+
+        items = []
+        for nar in narrative_list:
+            ws_info = full_ws_lookup_table[nar[6]]
+            items.append({'ws': ws_info, 'nar': nar})
+            self.cache[self._get_cache_key(ws_info)] = nar
+        return items
+
+    def _get_cache_key(self, ws_info):
+        return str(ws_info[0]) + '__' + str(ws_info[3])
+
+
+
+class NarrativeListUtils(object):
+
+    def __init__(self, cache_size):
+        self.narrativeInfo = NarrativeInfoCache(cache_size)
+
+
+    def list_public_narratives(self, wsClient):
+        # get all the workspaces marked as narratorials
+        ws_list = wsClient.list_workspace_info({})
+        ws_global_list = []
+        for ws_info in ws_list:
+            if ws_info[6] == 'r':  # indicates that this ws is globally readable
+                ws_global_list.append(ws_info)
+        # build a ws_list lookup table
+        ws_lookup_table = self._build_ws_lookup_table(ws_global_list)
+        # based on the WS lookup table, lookup the narratives
+        return self.narrativeInfo.get_info_list(ws_lookup_table, wsClient)
+
+
+    def list_my_narratives(self, my_user_id, wsClient):
+        # get all the workspaces marked as narratorials
+        ws_list = wsClient.list_workspace_info({'owners': ['my_user_id']})
+        ws_global_list = []
+        for ws_info in ws_list:
+            if ws_info[6] == 'r':  # indicates that this ws is globally readable
+                ws_global_list.append(ws_info)
+        # build a ws_list lookup table
+        ws_lookup_table = self._build_ws_lookup_table(ws_global_list)
+        # based on the WS lookup table, lookup the narratives
+        return self.narrativeInfo.get_info_list(ws_lookup_table, wsClient)
+
+    # TODO: missing shared Narratives- unclear what the right option for this is
+
+    def list_narratorials(self, wsClient):
+        # get all the workspaces marked as narratorials
+        ws_list = wsClient.list_workspace_info({'meta': {'narratorial': '1'}})
+        # build a ws_list lookup table
+        ws_lookup_table = self._build_ws_lookup_table(ws_list)
+        # based on the WS lookup table, lookup the narratives
+        return self.narrativeInfo.get_info_list(ws_lookup_table, wsClient)
+
+
+    def _build_ws_lookup_table(self, ws_list):
+        ''' builds a lookup table, skips anything without a 'narrative' metadata field set '''
+        ws_lookup_table = {}
+        for ws_info in ws_list:
+            if 'narrative' in ws_info[8]:
+                ws_lookup_table[ws_info[0]] = ws_info
+        return ws_lookup_table
+
+
+class NarratorialUtils(object):
+
+    def __init__(self):
+        pass
+
+    def _get_workspace_identity(self, wsid):
+        if str(wsid).isdigit():
+            return {'id': int(wsid)}
+        else:
+            return {'workspace': str(wsid)}
+
+    def set_narratorial(self, wsid, description, wsClient):
+        wsi = self._get_workspace_identity(wsid)
+        wsClient.alter_workspace_metadata({'wsi': wsi, 'new': {'narratorial': '1'}})
+        wsClient.alter_workspace_metadata({'wsi': wsi, 'new': {'narratorial_description': description}})
+
+    def remove_narratorial(self, wsid, wsClient):
+        wsi = self._get_workspace_identity(wsid)
+        wsClient.alter_workspace_metadata({'wsi': wsi, 'remove': ['narratorial', 'narratorial_description']})

--- a/lib/NarrativeService/NarrativeListUtils.py
+++ b/lib/NarrativeService/NarrativeListUtils.py
@@ -12,6 +12,7 @@ import pylru
 #     7 lock_status lockstat
 #     8 usermeta metadata
 
+
 class NarrativeInfoCache(object):
 
     def __init__(self, cache_size):
@@ -115,17 +116,28 @@ class NarrativeListUtils(object):
 
     def list_my_narratives(self, my_user_id, wsClient):
         # get all the workspaces marked as narratorials
-        ws_list = wsClient.list_workspace_info({'owners': ['my_user_id']})
-        ws_global_list = []
-        for ws_info in ws_list:
-            if ws_info[6] == 'r':  # indicates that this ws is globally readable
-                ws_global_list.append(ws_info)
+        ws_list = wsClient.list_workspace_info({'owners': [my_user_id]})
         # build a ws_list lookup table
-        ws_lookup_table = self._build_ws_lookup_table(ws_global_list)
+        ws_lookup_table = self._build_ws_lookup_table(ws_list)
         # based on the WS lookup table, lookup the narratives
         return self.narrativeInfo.get_info_list(ws_lookup_table, wsClient)
 
-    # TODO: missing shared Narratives- unclear what the right option for this is
+
+    def list_shared_narratives(self, my_user_id, wsClient):
+        # get all the workspaces marked as narratorials
+        ws_list = wsClient.list_workspace_info({})
+        ws_shared_list = []
+        for ws_info in ws_list:
+            if ws_info[2] == my_user_id:
+                continue
+            if ws_info[5] == 'n':  # indicates that this ws is globally readable
+                continue
+            ws_shared_list.append(ws_info)
+        # build a ws_list lookup table
+        ws_lookup_table = self._build_ws_lookup_table(ws_shared_list)
+        # based on the WS lookup table, lookup the narratives
+        return self.narrativeInfo.get_info_list(ws_lookup_table, wsClient)
+
 
     def list_narratorials(self, wsClient):
         # get all the workspaces marked as narratorials
@@ -159,7 +171,6 @@ class NarratorialUtils(object):
 
     def set_narratorial(self, wsid, description, wsClient):
         wsi = self._get_workspace_identity(wsid)
-        print('setting nar' + str(wsi))
         wsClient.alter_workspace_metadata({'wsi': wsi, 'new': {'narratorial': '1'}})
         wsClient.alter_workspace_metadata({'wsi': wsi, 'new': {'narratorial_description': description}})
 

--- a/lib/NarrativeService/NarrativeServiceClient.pm
+++ b/lib/NarrativeService/NarrativeServiceClient.pm
@@ -2435,7 +2435,7 @@ narratives has a value which is a reference to a list where each element is a Na
 
 List narratives
 type parameter indicates which narratives to return.
-Supported options are for now 'mine' or 'public'  TODO: 'shared'
+Supported options are for now 'mine', 'public', or 'shared'
 
 
 =item Definition

--- a/lib/NarrativeService/NarrativeServiceClient.pm
+++ b/lib/NarrativeService/NarrativeServiceClient.pm
@@ -81,20 +81,19 @@ sub new
     # We create an auth token, passing through the arguments that we were (hopefully) given.
 
     {
-	my $token = Bio::KBase::AuthToken->new(@args);
-	
-	if (!$token->error_message)
-	{
-	    $self->{token} = $token->token;
-	    $self->{client}->{token} = $token->token;
+	my %arg_hash2 = @args;
+	if (exists $arg_hash2{"token"}) {
+	    $self->{token} = $arg_hash2{"token"};
+	} elsif (exists $arg_hash2{"user_id"}) {
+	    my $token = Bio::KBase::AuthToken->new(@args);
+	    if (!$token->error_message) {
+	        $self->{token} = $token->token;
+	    }
 	}
-        else
-        {
-	    #
-	    # All methods in this module require authentication. In this case, if we
-	    # don't have a token, we can't continue.
-	    #
-	    die "Authentication failed: " . $token->error_message;
+	
+	if (exists $self->{token})
+	{
+	    $self->{client}->{token} = $self->{token};
 	}
     }
 
@@ -755,6 +754,470 @@ ListAvailableTypesOutput is a reference to a hash where the following keys are d
     }
 }
  
+
+
+=head2 list_narratorials
+
+  $return = $obj->list_narratorials($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a NarrativeService.ListNarratorialParams
+$return is a NarrativeService.NarratorialList
+ListNarratorialParams is a reference to a hash where the following keys are defined
+NarratorialList is a reference to a hash where the following keys are defined:
+	narratorials has a value which is a reference to a list where each element is a NarrativeService.Narratorial
+Narratorial is a reference to a hash where the following keys are defined:
+	ws has a value which is a NarrativeService.workspace_info
+	nar has a value which is a NarrativeService.object_info
+workspace_info is a reference to a list containing 9 items:
+	0: (id) an int
+	1: (workspace) a string
+	2: (owner) a string
+	3: (moddate) a string
+	4: (max_objid) an int
+	5: (user_permission) a string
+	6: (globalread) a string
+	7: (lockstat) a string
+	8: (metadata) a reference to a hash where the key is a string and the value is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) an int
+	1: (name) a string
+	2: (type) a string
+	3: (save_date) a NarrativeService.timestamp
+	4: (version) an int
+	5: (saved_by) a string
+	6: (wsid) an int
+	7: (workspace) a string
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a reference to a hash where the key is a string and the value is a string
+timestamp is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a NarrativeService.ListNarratorialParams
+$return is a NarrativeService.NarratorialList
+ListNarratorialParams is a reference to a hash where the following keys are defined
+NarratorialList is a reference to a hash where the following keys are defined:
+	narratorials has a value which is a reference to a list where each element is a NarrativeService.Narratorial
+Narratorial is a reference to a hash where the following keys are defined:
+	ws has a value which is a NarrativeService.workspace_info
+	nar has a value which is a NarrativeService.object_info
+workspace_info is a reference to a list containing 9 items:
+	0: (id) an int
+	1: (workspace) a string
+	2: (owner) a string
+	3: (moddate) a string
+	4: (max_objid) an int
+	5: (user_permission) a string
+	6: (globalread) a string
+	7: (lockstat) a string
+	8: (metadata) a reference to a hash where the key is a string and the value is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) an int
+	1: (name) a string
+	2: (type) a string
+	3: (save_date) a NarrativeService.timestamp
+	4: (version) an int
+	5: (saved_by) a string
+	6: (wsid) an int
+	7: (workspace) a string
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a reference to a hash where the key is a string and the value is a string
+timestamp is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub list_narratorials
+{
+    my($self, @args) = @_;
+
+# Authentication: optional
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function list_narratorials (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to list_narratorials:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'list_narratorials');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "NarrativeService.list_narratorials",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'list_narratorials',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method list_narratorials",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'list_narratorials',
+				       );
+    }
+}
+ 
+
+
+=head2 list_narratives
+
+  $return = $obj->list_narratives($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a NarrativeService.ListNarrativeParams
+$return is a NarrativeService.NarrativeList
+ListNarrativeParams is a reference to a hash where the following keys are defined:
+	type has a value which is a string
+NarrativeList is a reference to a hash where the following keys are defined:
+	narratives has a value which is a reference to a list where each element is a NarrativeService.Narrative
+Narrative is a reference to a hash where the following keys are defined:
+	ws has a value which is a NarrativeService.workspace_info
+	nar has a value which is a NarrativeService.object_info
+workspace_info is a reference to a list containing 9 items:
+	0: (id) an int
+	1: (workspace) a string
+	2: (owner) a string
+	3: (moddate) a string
+	4: (max_objid) an int
+	5: (user_permission) a string
+	6: (globalread) a string
+	7: (lockstat) a string
+	8: (metadata) a reference to a hash where the key is a string and the value is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) an int
+	1: (name) a string
+	2: (type) a string
+	3: (save_date) a NarrativeService.timestamp
+	4: (version) an int
+	5: (saved_by) a string
+	6: (wsid) an int
+	7: (workspace) a string
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a reference to a hash where the key is a string and the value is a string
+timestamp is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a NarrativeService.ListNarrativeParams
+$return is a NarrativeService.NarrativeList
+ListNarrativeParams is a reference to a hash where the following keys are defined:
+	type has a value which is a string
+NarrativeList is a reference to a hash where the following keys are defined:
+	narratives has a value which is a reference to a list where each element is a NarrativeService.Narrative
+Narrative is a reference to a hash where the following keys are defined:
+	ws has a value which is a NarrativeService.workspace_info
+	nar has a value which is a NarrativeService.object_info
+workspace_info is a reference to a list containing 9 items:
+	0: (id) an int
+	1: (workspace) a string
+	2: (owner) a string
+	3: (moddate) a string
+	4: (max_objid) an int
+	5: (user_permission) a string
+	6: (globalread) a string
+	7: (lockstat) a string
+	8: (metadata) a reference to a hash where the key is a string and the value is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) an int
+	1: (name) a string
+	2: (type) a string
+	3: (save_date) a NarrativeService.timestamp
+	4: (version) an int
+	5: (saved_by) a string
+	6: (wsid) an int
+	7: (workspace) a string
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a reference to a hash where the key is a string and the value is a string
+timestamp is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub list_narratives
+{
+    my($self, @args) = @_;
+
+# Authentication: optional
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function list_narratives (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to list_narratives:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'list_narratives');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "NarrativeService.list_narratives",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'list_narratives',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method list_narratives",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'list_narratives',
+				       );
+    }
+}
+ 
+
+
+=head2 set_narratorial
+
+  $return = $obj->set_narratorial($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a NarrativeService.SetNarratorialParams
+$return is a NarrativeService.SetNarratorialResult
+SetNarratorialParams is a reference to a hash where the following keys are defined:
+	ws has a value which is a string
+	description has a value which is a string
+SetNarratorialResult is a reference to a hash where the following keys are defined
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a NarrativeService.SetNarratorialParams
+$return is a NarrativeService.SetNarratorialResult
+SetNarratorialParams is a reference to a hash where the following keys are defined:
+	ws has a value which is a string
+	description has a value which is a string
+SetNarratorialResult is a reference to a hash where the following keys are defined
+
+
+=end text
+
+=item Description
+
+Allows a user to create a Narratorial given a WS they own. Right now
+anyone can do this, but we may restrict in the future to users that
+have a particular role.  Run simply as:
+    ns.set_narratorial({'ws':'MyWsName'}) or,
+    ns.set_narratorial({'ws':'4231'})
+
+=back
+
+=cut
+
+ sub set_narratorial
+{
+    my($self, @args) = @_;
+
+# Authentication: required
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function set_narratorial (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to set_narratorial:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'set_narratorial');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "NarrativeService.set_narratorial",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'set_narratorial',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method set_narratorial",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'set_narratorial',
+				       );
+    }
+}
+ 
+
+
+=head2 remove_narratorial
+
+  $return = $obj->remove_narratorial($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a NarrativeService.RemoveNarratorialParams
+$return is a NarrativeService.RemoveNarratorialResult
+RemoveNarratorialParams is a reference to a hash where the following keys are defined:
+	ws has a value which is a string
+RemoveNarratorialResult is a reference to a hash where the following keys are defined
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a NarrativeService.RemoveNarratorialParams
+$return is a NarrativeService.RemoveNarratorialResult
+RemoveNarratorialParams is a reference to a hash where the following keys are defined:
+	ws has a value which is a string
+RemoveNarratorialResult is a reference to a hash where the following keys are defined
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub remove_narratorial
+{
+    my($self, @args) = @_;
+
+# Authentication: required
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function remove_narratorial (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to remove_narratorial:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'remove_narratorial');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "NarrativeService.remove_narratorial",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'remove_narratorial',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method remove_narratorial",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'remove_narratorial',
+				       );
+    }
+}
+ 
   
 sub status
 {
@@ -798,16 +1261,16 @@ sub version {
             Bio::KBase::Exceptions::JSONRPC->throw(
                 error => $result->error_message,
                 code => $result->content->{code},
-                method_name => 'list_available_types',
+                method_name => 'remove_narratorial',
             );
         } else {
             return wantarray ? @{$result->result} : $result->result->[0];
         }
     } else {
         Bio::KBase::Exceptions::HTTP->throw(
-            error => "Error invoking method list_available_types",
+            error => "Error invoking method remove_narratorial",
             status_line => $self->{client}->status_line,
-            method_name => 'list_available_types',
+            method_name => 'remove_narratorial',
         );
     }
 }
@@ -1039,6 +1502,71 @@ a reference to a list containing 11 items:
 8: (chsum) a string
 9: (size) an int
 10: (meta) a reference to a hash where the key is a string and the value is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 workspace_info
+
+=over 4
+
+
+
+=item Description
+
+Information about a workspace.
+
+    ws_id id - the numerical ID of the workspace.
+    ws_name workspace - name of the workspace.
+    username owner - name of the user who owns (e.g. created) this workspace.
+    timestamp moddate - date when the workspace was last modified.
+    int max_objid - the maximum object ID appearing in this workspace.
+        Since cloning a workspace preserves object IDs, this number may be
+        greater than the number of objects in a newly cloned workspace.
+    permission user_permission - permissions for the authenticated user of
+        this workspace.
+    permission globalread - whether this workspace is globally readable.
+    lock_status lockstat - the status of the workspace lock.
+    usermeta metadata - arbitrary user-supplied metadata about
+        the workspace.
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a list containing 9 items:
+0: (id) an int
+1: (workspace) a string
+2: (owner) a string
+3: (moddate) a string
+4: (max_objid) an int
+5: (user_permission) a string
+6: (globalread) a string
+7: (lockstat) a string
+8: (metadata) a reference to a hash where the key is a string and the value is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a list containing 9 items:
+0: (id) an int
+1: (workspace) a string
+2: (owner) a string
+3: (moddate) a string
+4: (max_objid) an int
+5: (user_permission) a string
+6: (globalread) a string
+7: (lockstat) a string
+8: (metadata) a reference to a hash where the key is a string and the value is a string
 
 
 =end text
@@ -1730,6 +2258,323 @@ type_stat has a value which is a reference to a hash where the key is a string a
 a reference to a hash where the following keys are defined:
 type_stat has a value which is a reference to a hash where the key is a string and the value is an int
 
+
+=end text
+
+=back
+
+
+
+=head2 ListNarratorialParams
+
+=over 4
+
+
+
+=item Description
+
+Listing Narratives / Naratorials (plus Narratorial Management)
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined
+
+=end text
+
+=back
+
+
+
+=head2 Narratorial
+
+=over 4
+
+
+
+=item Description
+
+info for a narratorial
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ws has a value which is a NarrativeService.workspace_info
+nar has a value which is a NarrativeService.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ws has a value which is a NarrativeService.workspace_info
+nar has a value which is a NarrativeService.object_info
+
+
+=end text
+
+=back
+
+
+
+=head2 NarratorialList
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+narratorials has a value which is a reference to a list where each element is a NarrativeService.Narratorial
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+narratorials has a value which is a reference to a list where each element is a NarrativeService.Narratorial
+
+
+=end text
+
+=back
+
+
+
+=head2 Narrative
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ws has a value which is a NarrativeService.workspace_info
+nar has a value which is a NarrativeService.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ws has a value which is a NarrativeService.workspace_info
+nar has a value which is a NarrativeService.object_info
+
+
+=end text
+
+=back
+
+
+
+=head2 NarrativeList
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+narratives has a value which is a reference to a list where each element is a NarrativeService.Narrative
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+narratives has a value which is a reference to a list where each element is a NarrativeService.Narrative
+
+
+=end text
+
+=back
+
+
+
+=head2 ListNarrativeParams
+
+=over 4
+
+
+
+=item Description
+
+List narratives
+type parameter indicates which narratives to return.
+Supported options are for now 'mine' or 'public'  TODO: 'shared'
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+type has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+type has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 SetNarratorialParams
+
+=over 4
+
+
+
+=item Description
+
+ws field is a string, but properly interpreted whether it is a workspace
+name or ID
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ws has a value which is a string
+description has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ws has a value which is a string
+description has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 SetNarratorialResult
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined
+
+=end text
+
+=back
+
+
+
+=head2 RemoveNarratorialParams
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ws has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ws has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 RemoveNarratorialResult
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined
 
 =end text
 

--- a/lib/NarrativeService/NarrativeServiceClient.py
+++ b/lib/NarrativeService/NarrativeServiceClient.py
@@ -235,6 +235,135 @@ class NarrativeService(object):
             'NarrativeService.list_available_types',
             [params], self._service_ver, context)
 
+    def list_narratorials(self, params, context=None):
+        """
+        :param params: instance of type "ListNarratorialParams" (Listing
+           Narratives / Naratorials (plus Narratorial Management)) ->
+           structure:
+        :returns: instance of type "NarratorialList" -> structure: parameter
+           "narratorials" of list of type "Narratorial" (info for a
+           narratorial) -> structure: parameter "ws" of type "workspace_info"
+           (Information about a workspace. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - name of the workspace. username
+           owner - name of the user who owns (e.g. created) this workspace.
+           timestamp moddate - date when the workspace was last modified. int
+           max_objid - the maximum object ID appearing in this workspace.
+           Since cloning a workspace preserves object IDs, this number may be
+           greater than the number of objects in a newly cloned workspace.
+           permission user_permission - permissions for the authenticated
+           user of this workspace. permission globalread - whether this
+           workspace is globally readable. lock_status lockstat - the status
+           of the workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of Long, parameter "workspace" of String, parameter "owner" of
+           String, parameter "moddate" of String, parameter "max_objid" of
+           Long, parameter "user_permission" of String, parameter
+           "globalread" of String, parameter "lockstat" of String, parameter
+           "metadata" of mapping from String to String, parameter "nar" of
+           type "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of Long, parameter "name" of String,
+           parameter "type" of String, parameter "save_date" of type
+           "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
+           either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of String, parameter "wsid" of Long,
+           parameter "workspace" of String, parameter "chsum" of String,
+           parameter "size" of Long, parameter "meta" of mapping from String
+           to String
+        """
+        return self._client.call_method(
+            'NarrativeService.list_narratorials',
+            [params], self._service_ver, context)
+
+    def list_narratives(self, params, context=None):
+        """
+        :param params: instance of type "ListNarrativeParams" (List
+           narratives type parameter indicates which narratives to return.
+           Supported options are for now 'mine' or 'public'  TODO: 'shared')
+           -> structure: parameter "type" of String
+        :returns: instance of type "NarrativeList" -> structure: parameter
+           "narratives" of list of type "Narrative" -> structure: parameter
+           "ws" of type "workspace_info" (Information about a workspace.
+           ws_id id - the numerical ID of the workspace. ws_name workspace -
+           name of the workspace. username owner - name of the user who owns
+           (e.g. created) this workspace. timestamp moddate - date when the
+           workspace was last modified. int max_objid - the maximum object ID
+           appearing in this workspace. Since cloning a workspace preserves
+           object IDs, this number may be greater than the number of objects
+           in a newly cloned workspace. permission user_permission -
+           permissions for the authenticated user of this workspace.
+           permission globalread - whether this workspace is globally
+           readable. lock_status lockstat - the status of the workspace lock.
+           usermeta metadata - arbitrary user-supplied metadata about the
+           workspace.) -> tuple of size 9: parameter "id" of Long, parameter
+           "workspace" of String, parameter "owner" of String, parameter
+           "moddate" of String, parameter "max_objid" of Long, parameter
+           "user_permission" of String, parameter "globalread" of String,
+           parameter "lockstat" of String, parameter "metadata" of mapping
+           from String to String, parameter "nar" of type "object_info"
+           (Information about an object, including user provided metadata.
+           obj_id objid - the numerical id of the object. obj_name name - the
+           name of the object. type_string type - the type of the object.
+           timestamp save_date - the save date of the object. obj_ver ver -
+           the version of the object. username saved_by - the user that saved
+           or copied the object. ws_id wsid - the workspace containing the
+           object. ws_name workspace - the workspace containing the object.
+           string chsum - the md5 checksum of the object. int size - the size
+           of the object in bytes. usermeta meta - arbitrary user-supplied
+           metadata about the object.) -> tuple of size 11: parameter "objid"
+           of Long, parameter "name" of String, parameter "type" of String,
+           parameter "save_date" of type "timestamp" (A time in the format
+           YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "version" of Long, parameter "saved_by" of
+           String, parameter "wsid" of Long, parameter "workspace" of String,
+           parameter "chsum" of String, parameter "size" of Long, parameter
+           "meta" of mapping from String to String
+        """
+        return self._client.call_method(
+            'NarrativeService.list_narratives',
+            [params], self._service_ver, context)
+
+    def set_narratorial(self, params, context=None):
+        """
+        Allows a user to create a Narratorial given a WS they own. Right now
+        anyone can do this, but we may restrict in the future to users that
+        have a particular role.  Run simply as:
+            ns.set_narratorial({'ws':'MyWsName'}) or,
+            ns.set_narratorial({'ws':'4231'})
+        :param params: instance of type "SetNarratorialParams" (ws field is a
+           string, but properly interpreted whether it is a workspace name or
+           ID) -> structure: parameter "ws" of String, parameter
+           "description" of String
+        :returns: instance of type "SetNarratorialResult" -> structure:
+        """
+        return self._client.call_method(
+            'NarrativeService.set_narratorial',
+            [params], self._service_ver, context)
+
+    def remove_narratorial(self, params, context=None):
+        """
+        :param params: instance of type "RemoveNarratorialParams" ->
+           structure: parameter "ws" of String
+        :returns: instance of type "RemoveNarratorialResult" -> structure:
+        """
+        return self._client.call_method(
+            'NarrativeService.remove_narratorial',
+            [params], self._service_ver, context)
+
     def status(self, context=None):
         return self._client.call_method('NarrativeService.status',
                                         [], self._service_ver, context)

--- a/lib/NarrativeService/NarrativeServiceClient.py
+++ b/lib/NarrativeService/NarrativeServiceClient.py
@@ -290,8 +290,8 @@ class NarrativeService(object):
         """
         :param params: instance of type "ListNarrativeParams" (List
            narratives type parameter indicates which narratives to return.
-           Supported options are for now 'mine' or 'public'  TODO: 'shared')
-           -> structure: parameter "type" of String
+           Supported options are for now 'mine', 'public', or 'shared') ->
+           structure: parameter "type" of String
         :returns: instance of type "NarrativeList" -> structure: parameter
            "narratives" of list of type "Narrative" -> structure: parameter
            "ws" of type "workspace_info" (Information about a workspace.

--- a/lib/NarrativeService/NarrativeServiceImpl.py
+++ b/lib/NarrativeService/NarrativeServiceImpl.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #BEGIN_HEADER
+from Workspace.WorkspaceClient import Workspace
 from NarrativeService.NarrativeManager import NarrativeManager
 from NarrativeService.DynamicServiceCache import DynamicServiceCache
+from NarrativeService.NarrativeListUtils import NarrativeListUtils
 #END_HEADER
 
 
@@ -20,9 +22,9 @@ class NarrativeService:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.0.1"
-    GIT_URL = "https://github.com/rsutormin/NarrativeService"
-    GIT_COMMIT_HASH = "ef419c36065c6969c34b3f0ab63791ace8892177"
+    VERSION = "0.0.3"
+    GIT_URL = "git@github.com:kbaseapps/NarrativeService"
+    GIT_COMMIT_HASH = "01e0b71ddcf0e375e44fe5cc79f56a92e91febc0"
 
     #BEGIN_CLASS_HEADER
     def _nm(self, ctx):
@@ -43,6 +45,8 @@ class NarrativeService:
         self.dataPaletteCache = DynamicServiceCache(self.serviceWizardURL,
                                                     config['datapaletteservice-version'],
                                                     'DataPaletteService')
+
+        self.narListUtils = NarrativeListUtils(config['narrative-list-cache-size'])
         #END_CONSTRUCTOR
         pass
 
@@ -314,6 +318,170 @@ class NarrativeService:
         # At some point might do deeper type checking...
         if not isinstance(returnVal, dict):
             raise ValueError('Method list_available_types return value ' +
+                             'returnVal is not type dict as required.')
+        # return the results
+        return [returnVal]
+
+    def list_narratorials(self, ctx, params):
+        """
+        :param params: instance of type "ListNarratorialParams" (Listing
+           Narratives / Naratorials (plus Narratorial Management)) ->
+           structure:
+        :returns: instance of type "NarratorialList" -> structure: parameter
+           "narratorials" of list of type "Narratorial" (info for a
+           narratorial) -> structure: parameter "ws" of type "workspace_info"
+           (Information about a workspace. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - name of the workspace. username
+           owner - name of the user who owns (e.g. created) this workspace.
+           timestamp moddate - date when the workspace was last modified. int
+           max_objid - the maximum object ID appearing in this workspace.
+           Since cloning a workspace preserves object IDs, this number may be
+           greater than the number of objects in a newly cloned workspace.
+           permission user_permission - permissions for the authenticated
+           user of this workspace. permission globalread - whether this
+           workspace is globally readable. lock_status lockstat - the status
+           of the workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of Long, parameter "workspace" of String, parameter "owner" of
+           String, parameter "moddate" of String, parameter "max_objid" of
+           Long, parameter "user_permission" of String, parameter
+           "globalread" of String, parameter "lockstat" of String, parameter
+           "metadata" of mapping from String to String, parameter "nar" of
+           type "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of Long, parameter "name" of String,
+           parameter "type" of String, parameter "save_date" of type
+           "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
+           either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of String, parameter "wsid" of Long,
+           parameter "workspace" of String, parameter "chsum" of String,
+           parameter "size" of Long, parameter "meta" of mapping from String
+           to String
+        """
+        # ctx is the context object
+        # return variables are: returnVal
+        #BEGIN list_narratorials
+        ws = Workspace(self.workspaceURL, token=ctx["token"])
+        returnVal = self.narListUtils.list_narratorials(ws)
+        #END list_narratorials
+
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, dict):
+            raise ValueError('Method list_narratorials return value ' +
+                             'returnVal is not type dict as required.')
+        # return the results
+        return [returnVal]
+
+    def list_narratives(self, ctx, params):
+        """
+        :param params: instance of type "ListNarrativeParams" (List
+           narratives type parameter indicates which narratives to return.
+           Supported options are for now 'mine' or 'public'  TODO: 'shared')
+           -> structure: parameter "type" of String
+        :returns: instance of type "NarrativeList" -> structure: parameter
+           "narratives" of list of type "Narrative" -> structure: parameter
+           "ws" of type "workspace_info" (Information about a workspace.
+           ws_id id - the numerical ID of the workspace. ws_name workspace -
+           name of the workspace. username owner - name of the user who owns
+           (e.g. created) this workspace. timestamp moddate - date when the
+           workspace was last modified. int max_objid - the maximum object ID
+           appearing in this workspace. Since cloning a workspace preserves
+           object IDs, this number may be greater than the number of objects
+           in a newly cloned workspace. permission user_permission -
+           permissions for the authenticated user of this workspace.
+           permission globalread - whether this workspace is globally
+           readable. lock_status lockstat - the status of the workspace lock.
+           usermeta metadata - arbitrary user-supplied metadata about the
+           workspace.) -> tuple of size 9: parameter "id" of Long, parameter
+           "workspace" of String, parameter "owner" of String, parameter
+           "moddate" of String, parameter "max_objid" of Long, parameter
+           "user_permission" of String, parameter "globalread" of String,
+           parameter "lockstat" of String, parameter "metadata" of mapping
+           from String to String, parameter "nar" of type "object_info"
+           (Information about an object, including user provided metadata.
+           obj_id objid - the numerical id of the object. obj_name name - the
+           name of the object. type_string type - the type of the object.
+           timestamp save_date - the save date of the object. obj_ver ver -
+           the version of the object. username saved_by - the user that saved
+           or copied the object. ws_id wsid - the workspace containing the
+           object. ws_name workspace - the workspace containing the object.
+           string chsum - the md5 checksum of the object. int size - the size
+           of the object in bytes. usermeta meta - arbitrary user-supplied
+           metadata about the object.) -> tuple of size 11: parameter "objid"
+           of Long, parameter "name" of String, parameter "type" of String,
+           parameter "save_date" of type "timestamp" (A time in the format
+           YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "version" of Long, parameter "saved_by" of
+           String, parameter "wsid" of Long, parameter "workspace" of String,
+           parameter "chsum" of String, parameter "size" of Long, parameter
+           "meta" of mapping from String to String
+        """
+        # ctx is the context object
+        # return variables are: returnVal
+        #BEGIN list_narratives
+        #END list_narratives
+
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, dict):
+            raise ValueError('Method list_narratives return value ' +
+                             'returnVal is not type dict as required.')
+        # return the results
+        return [returnVal]
+
+    def set_narratorial(self, ctx, params):
+        """
+        Allows a user to create a Narratorial given a WS they own. Right now
+        anyone can do this, but we may restrict in the future to users that
+        have a particular role.  Run simply as:
+            ns.set_narratorial({'ws':'MyWsName'}) or,
+            ns.set_narratorial({'ws':'4231'})
+        :param params: instance of type "SetNarratorialParams" (ws field is a
+           string, but properly interpreted whether it is a workspace name or
+           ID) -> structure: parameter "ws" of String, parameter
+           "description" of String
+        :returns: instance of type "SetNarratorialResult" -> structure:
+        """
+        # ctx is the context object
+        # return variables are: returnVal
+        #BEGIN set_narratorial
+        returnVal = {}
+        #END set_narratorial
+
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, dict):
+            raise ValueError('Method set_narratorial return value ' +
+                             'returnVal is not type dict as required.')
+        # return the results
+        return [returnVal]
+
+    def remove_narratorial(self, ctx, params):
+        """
+        :param params: instance of type "RemoveNarratorialParams" ->
+           structure: parameter "ws" of String
+        :returns: instance of type "RemoveNarratorialResult" -> structure:
+        """
+        # ctx is the context object
+        # return variables are: returnVal
+        #BEGIN remove_narratorial
+        #END remove_narratorial
+
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, dict):
+            raise ValueError('Method remove_narratorial return value ' +
                              'returnVal is not type dict as required.')
         # return the results
         return [returnVal]

--- a/lib/NarrativeService/NarrativeServiceServer.py
+++ b/lib/NarrativeService/NarrativeServiceServer.py
@@ -353,6 +353,22 @@ class Application(object):
                              name='NarrativeService.list_available_types',
                              types=[dict])
         self.method_authentication['NarrativeService.list_available_types'] = 'required'  # noqa
+        self.rpc_service.add(impl_NarrativeService.list_narratorials,
+                             name='NarrativeService.list_narratorials',
+                             types=[dict])
+        self.method_authentication['NarrativeService.list_narratorials'] = 'optional'  # noqa
+        self.rpc_service.add(impl_NarrativeService.list_narratives,
+                             name='NarrativeService.list_narratives',
+                             types=[dict])
+        self.method_authentication['NarrativeService.list_narratives'] = 'optional'  # noqa
+        self.rpc_service.add(impl_NarrativeService.set_narratorial,
+                             name='NarrativeService.set_narratorial',
+                             types=[dict])
+        self.method_authentication['NarrativeService.set_narratorial'] = 'required'  # noqa
+        self.rpc_service.add(impl_NarrativeService.remove_narratorial,
+                             name='NarrativeService.remove_narratorial',
+                             types=[dict])
+        self.method_authentication['NarrativeService.remove_narratorial'] = 'required'  # noqa
         self.rpc_service.add(impl_NarrativeService.status,
                              name='NarrativeService.status',
                              types=[dict])

--- a/lib/Workspace/WorkspaceClient.py
+++ b/lib/Workspace/WorkspaceClient.py
@@ -69,26 +69,28 @@ class Workspace(object):
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -117,12 +119,10 @@ class Workspace(object):
            overwritten. list<string> remove - these keys will be removed from
            the workspace metadata key/value pairs.) -> structure: parameter
            "wsi" of type "WorkspaceIdentity" (A workspace identifier. Select
-           a workspace by one, and only one, of the numerical id or name,
-           where the name can also be a KBase ID including the numerical id,
-           e.g. kb|ws.35. ws_id id - the numerical ID of the workspace.
-           ws_name workspace - name of the workspace or the workspace ID in
-           KBase format, e.g. kb|ws.78.) -> structure: parameter "workspace"
-           of type "ws_name" (A string used as a name for a workspace. Any
+           a workspace by one, and only one, of the numerical id or name.
+           ws_id id - the numerical ID of the workspace. ws_name workspace -
+           the name of the workspace.) -> structure: parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
            string consisting of alphanumeric characters and "_", ".", or "-"
            that is not an integer is acceptable. The name may optionally be
            prefixed with the workspace owner's user name and a colon, e.g.
@@ -150,13 +150,15 @@ class Workspace(object):
            A free-text description of the new workspace, 1000 characters max.
            Longer strings will be mercilessly and brutally truncated.
            usermeta meta - arbitrary user-supplied metadata for the
-           workspace.) -> structure: parameter "wsi" of type
+           workspace. list<ObjectIdentity> exclude - exclude the specified
+           objects from the cloned workspace. Either an object ID or a object
+           name must be specified in each ObjectIdentity - any supplied
+           reference strings, workspace names or IDs, and versions are
+           ignored.) -> structure: parameter "wsi" of type
            "WorkspaceIdentity" (A workspace identifier. Select a workspace by
-           one, and only one, of the numerical id or name, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id id - the numerical ID of the workspace. ws_name workspace -
-           name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78.) -> structure: parameter "workspace" of type "ws_name"
+           one, and only one, of the numerical id or name. ws_id id - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace.) -> structure: parameter "workspace" of type "ws_name"
            (A string used as a name for a workspace. Any string consisting of
            alphanumeric characters and "_", ".", or "-" that is not an
            integer is acceptable. The name may optionally be prefixed with
@@ -173,31 +175,63 @@ class Workspace(object):
            'w' - read/write. 'r' - read. 'n' - no permissions.), parameter
            "description" of String, parameter "meta" of type "usermeta" (User
            provided metadata about an object. Arbitrary key-value pairs
-           provided by the user.) -> mapping from String to String
+           provided by the user.) -> mapping from String to String, parameter
+           "exclude" of list of type "ObjectIdentity" (An object identifier.
+           Select an object by either: One, and only one, of the numerical id
+           or name of the workspace. ws_id wsid - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace. AND One,
+           and only one, of the numerical id or name of the object. obj_id
+           objid- the numerical ID of the object. obj_name name - name of the
+           object. OPTIONALLY obj_ver ver - the version of the object. OR an
+           object reference string: obj_ref ref - an object reference
+           string.) -> structure: parameter "workspace" of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of type "workspace_info" (Information about a
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -227,10 +261,8 @@ class Workspace(object):
                 workspace cannot be made private.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -242,26 +274,28 @@ class Workspace(object):
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -284,22 +318,21 @@ class Workspace(object):
         Retrieves the metadata associated with the specified workspace.
         Provided for backwards compatibility. 
         @deprecated Workspace.get_workspace_info
-        :param params: instance of type "get_workspacemeta_params" (Input
-           parameters for the "get_workspacemeta" function. Provided for
-           backwards compatibility. One, and only one of: ws_name workspace -
-           name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. ws_id id - the numerical ID of the workspace. Optional
-           arguments: string auth - the authentication token of the KBase
-           account accessing the workspace. Overrides the client provided
-           authorization credentials if they exist. @deprecated
-           Workspace.WorkspaceIdentity) -> structure: parameter "workspace"
-           of type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
-           kbasetest:my_workspace.), parameter "id" of type "ws_id" (The
-           unique, permanent numerical ID of a workspace.), parameter "auth"
-           of String
+        :param params: instance of type "get_workspacemeta_params"
+           (DEPRECATED Input parameters for the "get_workspacemeta" function.
+           Provided for backwards compatibility. One, and only one of:
+           ws_name workspace - name of the workspace. ws_id id - the
+           numerical ID of the workspace. Optional arguments: string auth -
+           the authentication token of the KBase account accessing the
+           workspace. Overrides the client provided authorization credentials
+           if they exist. @deprecated Workspace.WorkspaceIdentity) ->
+           structure: parameter "workspace" of type "ws_name" (A string used
+           as a name for a workspace. Any string consisting of alphanumeric
+           characters and "_", ".", or "-" that is not an integer is
+           acceptable. The name may optionally be prefixed with the workspace
+           owner's user name and a colon, e.g. kbasetest:my_workspace.),
+           parameter "id" of type "ws_id" (The unique, permanent numerical ID
+           of a workspace.), parameter "auth" of String
         :returns: instance of type "workspace_metadata" (Meta data associated
            with a workspace. Provided for backwards compatibility. To be
            replaced by workspace_info. ws_name id - name of the workspace
@@ -341,10 +374,8 @@ class Workspace(object):
         Get information associated with a workspace.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -356,26 +387,28 @@ class Workspace(object):
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -398,10 +431,8 @@ class Workspace(object):
         Get a workspace's description.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -421,12 +452,11 @@ class Workspace(object):
         :param params: instance of type "SetPermissionsParams" (Input
            parameters for the "set_permissions" function. One, and only one,
            of the following is required: ws_id id - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. Required arguments:
-           permission new_permission - the permission to assign to the users.
-           list<username> users - the users whose permissions will be
-           altered.) -> structure: parameter "workspace" of type "ws_name" (A
-           string used as a name for a workspace. Any string consisting of
+           workspace. ws_name workspace - the name of the workspace. Required
+           arguments: permission new_permission - the permission to assign to
+           the users. list<username> users - the users whose permissions will
+           be altered.) -> structure: parameter "workspace" of type "ws_name"
+           (A string used as a name for a workspace. Any string consisting of
            alphanumeric characters and "_", ".", or "-" that is not an
            integer is acceptable. The name may optionally be prefixed with
            the workspace owner's user name and a colon, e.g.
@@ -448,22 +478,21 @@ class Workspace(object):
         :param params: instance of type "SetGlobalPermissionsParams" (Input
            parameters for the "set_global_permission" function. One, and only
            one, of the following is required: ws_id id - the numerical ID of
-           the workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. Required arguments:
-           permission new_permission - the permission to assign to all users,
-           either 'n' or 'r'. 'r' means that all users will be able to read
-           the workspace; otherwise users must have specific permission to
-           access the workspace.) -> structure: parameter "workspace" of type
-           "ws_name" (A string used as a name for a workspace. Any string
-           consisting of alphanumeric characters and "_", ".", or "-" that is
-           not an integer is acceptable. The name may optionally be prefixed
-           with the workspace owner's user name and a colon, e.g.
-           kbasetest:my_workspace.), parameter "id" of type "ws_id" (The
-           unique, permanent numerical ID of a workspace.), parameter
-           "new_permission" of type "permission" (Represents the permissions
-           a user or users have to a workspace: 'a' - administrator. All
-           operations allowed. 'w' - read/write. 'r' - read. 'n' - no
-           permissions.)
+           the workspace. ws_name workspace - the name of the workspace.
+           Required arguments: permission new_permission - the permission to
+           assign to all users, either 'n' or 'r'. 'r' means that all users
+           will be able to read the workspace; otherwise users must have
+           specific permission to access the workspace.) -> structure:
+           parameter "workspace" of type "ws_name" (A string used as a name
+           for a workspace. Any string consisting of alphanumeric characters
+           and "_", ".", or "-" that is not an integer is acceptable. The
+           name may optionally be prefixed with the workspace owner's user
+           name and a colon, e.g. kbasetest:my_workspace.), parameter "id" of
+           type "ws_id" (The unique, permanent numerical ID of a workspace.),
+           parameter "new_permission" of type "permission" (Represents the
+           permissions a user or users have to a workspace: 'a' -
+           administrator. All operations allowed. 'w' - read/write. 'r' -
+           read. 'n' - no permissions.)
         """
         return self._client.call_method(
             'Workspace.set_global_permission',
@@ -475,16 +504,15 @@ class Workspace(object):
         :param params: instance of type "SetWorkspaceDescriptionParams"
            (Input parameters for the "set_workspace_description" function.
            One, and only one, of the following is required: ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.
-           Optional arguments: string description - A free-text description
-           of the workspace, 1000 characters max. Longer strings will be
-           mercilessly and brutally truncated. If omitted, the description is
-           set to null.) -> structure: parameter "workspace" of type
-           "ws_name" (A string used as a name for a workspace. Any string
-           consisting of alphanumeric characters and "_", ".", or "-" that is
-           not an integer is acceptable. The name may optionally be prefixed
-           with the workspace owner's user name and a colon, e.g.
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. Optional arguments: string description - A free-text
+           description of the workspace, 1000 characters max. Longer strings
+           will be mercilessly and brutally truncated. If omitted, the
+           description is set to null.) -> structure: parameter "workspace"
+           of type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "id" of type "ws_id" (The
            unique, permanent numerical ID of a workspace.), parameter
            "description" of String
@@ -501,11 +529,9 @@ class Workspace(object):
            the workspaces for which to return the permissions, maximum 1000.)
            -> structure: parameter "workspaces" of list of type
            "WorkspaceIdentity" (A workspace identifier. Select a workspace by
-           one, and only one, of the numerical id or name, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id id - the numerical ID of the workspace. ws_name workspace -
-           name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78.) -> structure: parameter "workspace" of type "ws_name"
+           one, and only one, of the numerical id or name. ws_id id - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace.) -> structure: parameter "workspace" of type "ws_name"
            (A string used as a name for a workspace. Any string consisting of
            alphanumeric characters and "_", ".", or "-" that is not an
            integer is acceptable. The name may optionally be prefixed with
@@ -527,12 +553,11 @@ class Workspace(object):
     def get_permissions(self, wsi, context=None):
         """
         Get permissions for a workspace.
+        @deprecated get_permissions_mass
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -605,22 +630,23 @@ class Workspace(object):
            the object is stored string ref - Deprecated. Always returns the
            empty string. string chsum - the md5 checksum of the object.
            usermeta metadata - arbitrary user-supplied metadata about the
-           object. obj_id objid - the numerical id of the object.) -> tuple
-           of size 12: parameter "id" of type "obj_name" (A string used as a
-           name for an object. Any string consisting of alphanumeric
-           characters and the characters |._- that is not an integer is
-           acceptable.), parameter "type" of type "type_string" (A type
-           string. Specifies the type and its version in a single string in
-           the format [module].[typename]-[major].[minor]: module - a string.
-           The module name of the typespec containing the type. typename - a
-           string. The name of the type as assigned by the typedef statement.
-           major - an integer. The major version of the type. A change in the
-           major version implies the type has changed in a non-backwards
-           compatible way. minor - an integer. The minor version of the type.
-           A change in the minor version implies that the type has changed in
-           a way that is backwards compatible with previous type definitions.
-           In many cases, the major and minor versions are optional, and if
-           not provided the most recent version will be used. Example:
+           object. obj_id objid - the numerical id of the object. @deprecated
+           object_info) -> tuple of size 12: parameter "id" of type
+           "obj_name" (A string used as a name for an object. Any string
+           consisting of alphanumeric characters and the characters |._- that
+           is not an integer is acceptable.), parameter "type" of type
+           "type_string" (A type string. Specifies the type and its version
+           in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
            MyModule.MyType-3.1), parameter "moddate" of type "timestamp" (A
            time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
            character Z (representing the UTC timezone) or the difference in
@@ -652,83 +678,83 @@ class Workspace(object):
         :param params: instance of type "SaveObjectsParams" (Input parameters
            for the "save_objects" function. One, and only one, of the
            following is required: ws_id id - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. Required arguments:
-           list<ObjectSaveData> objects - the objects to save.) -> structure:
-           parameter "workspace" of type "ws_name" (A string used as a name
-           for a workspace. Any string consisting of alphanumeric characters
-           and "_", ".", or "-" that is not an integer is acceptable. The
-           name may optionally be prefixed with the workspace owner's user
-           name and a colon, e.g. kbasetest:my_workspace.), parameter "id" of
-           type "ws_id" (The unique, permanent numerical ID of a workspace.),
-           parameter "objects" of list of type "ObjectSaveData" (An object
-           and associated data required for saving. Required arguments:
-           type_string type - the type of the object. Omit the version
-           information to use the latest version. UnspecifiedObject data -
-           the object data. Optional arguments: One of an object name or id.
-           If no name or id is provided the name will be set to 'auto' with
-           the object id appended as a string, possibly with -\d+ appended if
-           that object id already exists as a name. obj_name name - the name
-           of the object. obj_id objid - the id of the object to save over.
-           usermeta meta - arbitrary user-supplied metadata for the object,
-           not to exceed 16kb; if the object type specifies automatic
-           metadata extraction with the 'meta ws' annotation, and your
-           metadata name conflicts, then your metadata will be silently
-           overwritten. list<ProvenanceAction> provenance - provenance data
-           for the object. boolean hidden - true if this object should not be
-           listed when listing workspace objects.) -> structure: parameter
-           "type" of type "type_string" (A type string. Specifies the type
-           and its version in a single string in the format
-           [module].[typename]-[major].[minor]: module - a string. The module
-           name of the typespec containing the type. typename - a string. The
-           name of the type as assigned by the typedef statement. major - an
-           integer. The major version of the type. A change in the major
-           version implies the type has changed in a non-backwards compatible
-           way. minor - an integer. The minor version of the type. A change
-           in the minor version implies that the type has changed in a way
-           that is backwards compatible with previous type definitions. In
-           many cases, the major and minor versions are optional, and if not
-           provided the most recent version will be used. Example:
-           MyModule.MyType-3.1), parameter "data" of unspecified object,
-           parameter "name" of type "obj_name" (A string used as a name for
-           an object. Any string consisting of alphanumeric characters and
-           the characters |._- that is not an integer is acceptable.),
-           parameter "objid" of type "obj_id" (The unique, permanent
-           numerical ID of an object.), parameter "meta" of type "usermeta"
-           (User provided metadata about an object. Arbitrary key-value pairs
-           provided by the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
+           workspace. ws_name workspace - the name of the workspace. Required
+           arguments: list<ObjectSaveData> objects - the objects to save.) ->
+           structure: parameter "workspace" of type "ws_name" (A string used
+           as a name for a workspace. Any string consisting of alphanumeric
+           characters and "_", ".", or "-" that is not an integer is
+           acceptable. The name may optionally be prefixed with the workspace
+           owner's user name and a colon, e.g. kbasetest:my_workspace.),
+           parameter "id" of type "ws_id" (The unique, permanent numerical ID
+           of a workspace.), parameter "objects" of list of type
+           "ObjectSaveData" (An object and associated data required for
+           saving. Required arguments: type_string type - the type of the
+           object. Omit the version information to use the latest version.
+           UnspecifiedObject data - the object data. Optional arguments: One
+           of an object name or id. If no name or id is provided the name
+           will be set to 'auto' with the object id appended as a string,
+           possibly with -\d+ appended if that object id already exists as a
+           name. obj_name name - the name of the object. obj_id objid - the
+           id of the object to save over. usermeta meta - arbitrary
+           user-supplied metadata for the object, not to exceed 16kb; if the
+           object type specifies automatic metadata extraction with the 'meta
+           ws' annotation, and your metadata name conflicts, then your
+           metadata will be silently overwritten. list<ProvenanceAction>
+           provenance - provenance data for the object. boolean hidden - true
+           if this object should not be listed when listing workspace
+           objects.) -> structure: parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "data" of
+           unspecified object, parameter "name" of type "obj_name" (A string
+           used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "objid" of type "obj_id" (The
+           unique, permanent numerical ID of an object.), parameter "meta" of
+           type "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String, parameter "provenance" of list of type "ProvenanceAction"
+           (A provenance action. A provenance action (PA) is an action taken
+           while transforming one data object to another. There may be
+           several PAs taken in series. A PA is typically running a script,
+           running an api command, etc. All of the following fields are
+           optional, but more information provided equates to better data
+           provenance. resolved_ws_objects should never be set by the user;
+           it is set by the workspace service when returning data. On input,
+           only one of the time or epoch may be supplied. Both are supplied
+           on output. The maximum size of the entire provenance object,
+           including all actions, is 1MB. timestamp time - the time the
+           action was started epoch epoch - the time the action was started.
+           string caller - the name or id of the invoker of this provenance
+           action. In most cases, this will be the same for all PAs. string
+           service - the name of the service that performed this action.
+           string service_ver - the version of the service that performed
+           this action. string method - the method of the service that
+           performed this action. list<UnspecifiedObject> method_params - the
+           parameters of the method that performed this action. If an object
+           in the parameters is a workspace object, also put the object
+           reference in the input_ws_object list. string script - the name of
+           the script that performed this action. string script_ver - the
+           version of the script that performed this action. string
+           script_command_line - the command line provided to the script that
+           performed this action. If workspace objects were provided in the
+           command line, also put the object reference in the input_ws_object
+           list. list<ref_string> input_ws_objects - the workspace objects
+           that were used as input to this action; typically these will also
+           be present as parts of the method_params or the
+           script_command_line arguments. A reference path into the object
+           graph may be supplied. list<obj_ref> resolved_ws_objects - the
+           workspace objects ids from input_ws_objects resolved to permanent
+           workspace object references by the workspace service. list<string>
            intermediate_incoming - if the previous action produced output
            that 1) was not stored in a referrable way, and 2) is used as
            input for this action, provide it with an arbitrary and unique ID
@@ -756,37 +782,30 @@ class Workspace(object):
            of String, parameter "method" of String, parameter "method_params"
            of list of unspecified object, parameter "script" of String,
            parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           of String, parameter "input_ws_objects" of list of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -924,29 +943,30 @@ class Workspace(object):
            Always returns the empty string. string chsum - the md5 checksum
            of the object. usermeta metadata - arbitrary user-supplied
            metadata about the object. obj_id objid - the numerical id of the
-           object.) -> tuple of size 12: parameter "id" of type "obj_name" (A
-           string used as a name for an object. Any string consisting of
-           alphanumeric characters and the characters |._- that is not an
-           integer is acceptable.), parameter "type" of type "type_string" (A
-           type string. Specifies the type and its version in a single string
-           in the format [module].[typename]-[major].[minor]: module - a
-           string. The module name of the typespec containing the type.
-           typename - a string. The name of the type as assigned by the
-           typedef statement. major - an integer. The major version of the
-           type. A change in the major version implies the type has changed
-           in a non-backwards compatible way. minor - an integer. The minor
-           version of the type. A change in the minor version implies that
-           the type has changed in a way that is backwards compatible with
-           previous type definitions. In many cases, the major and minor
-           versions are optional, and if not provided the most recent version
-           will be used. Example: MyModule.MyType-3.1), parameter "moddate"
-           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
-           where Z is either the character Z (representing the UTC timezone)
-           or the difference in time to UTC in the format +/-HHMM, eg:
-           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "instance" of
-           Long, parameter "command" of String, parameter "lastmodifier" of
-           type "username" (Login name of a KBase user account.), parameter
+           object. @deprecated object_info) -> tuple of size 12: parameter
+           "id" of type "obj_name" (A string used as a name for an object.
+           Any string consisting of alphanumeric characters and the
+           characters |._- that is not an integer is acceptable.), parameter
+           "type" of type "type_string" (A type string. Specifies the type
+           and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "moddate" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "instance" of Long,
+           parameter "command" of String, parameter "lastmodifier" of type
+           "username" (Login name of a KBase user account.), parameter
            "owner" of type "username" (Login name of a KBase user account.),
            parameter "workspace" of type "ws_name" (A string used as a name
            for a workspace. Any string consisting of alphanumeric characters
@@ -970,11 +990,9 @@ class Workspace(object):
         @deprecated Workspace.get_objects2
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -992,18 +1010,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of type "ObjectProvenanceInfo" (DEPRECATED
            The provenance and supplemental info for an object. object_info
            info - information about the object. list<ProvenanceAction>
@@ -1093,12 +1107,13 @@ class Workspace(object):
            script_command_line - the command line provided to the script that
            performed this action. If workspace objects were provided in the
            command line, also put the object reference in the input_ws_object
-           list. list<obj_ref> input_ws_objects - the workspace objects that
-           were used as input to this action; typically these will also be
-           present as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
+           list. list<ref_string> input_ws_objects - the workspace objects
+           that were used as input to this action; typically these will also
+           be present as parts of the method_params or the
+           script_command_line arguments. A reference path into the object
+           graph may be supplied. list<obj_ref> resolved_ws_objects - the
+           workspace objects ids from input_ws_objects resolved to permanent
+           workspace object references by the workspace service. list<string>
            intermediate_incoming - if the previous action produced output
            that 1) was not stored in a referrable way, and 2) is used as
            input for this action, provide it with an arbitrary and unique ID
@@ -1126,37 +1141,30 @@ class Workspace(object):
            of String, parameter "method" of String, parameter "method_params"
            of list of unspecified object, parameter "script" of String,
            parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           of String, parameter "input_ws_objects" of list of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -1211,37 +1219,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_object_provenance',
@@ -1254,11 +1255,9 @@ class Workspace(object):
         @deprecated Workspace.get_objects2
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -1276,29 +1275,27 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of type "ObjectData" (The data and
            supplemental info for an object. UnspecifiedObject data - the
            object's data or subset data. object_info info - information about
-           the object. list<ProvenanceAction> provenance - the object's
+           the object. list<obj_ref> path - the path to the object through
+           the object reference graph. All the references in the path are
+           absolute. list<ProvenanceAction> provenance - the object's
            provenance. username creator - the user that first saved the
            object to the workspace. ws_id orig_wsid - the id of the workspace
            in which this object was originally saved. Missing for objects
            saved prior to version 0.4.1. timestamp created - the date the
            object was first saved to the workspace. epoch epoch - the date
-           the object was first saved to the workspace. list<obj_ref> - the
-           references contained within the object. obj_ref copied - the
+           the object was first saved to the workspace. list<obj_ref> refs -
+           the references contained within the object. obj_ref copied - the
            reference of the source object if this object is a copy and the
            copy source exists and is accessible. null otherwise. boolean
            copy_source_inaccessible - true if the object was copied from
@@ -1351,97 +1348,101 @@ class Workspace(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
-           list<ExternalDataUnit> external_data - data external to the
-           workspace that was either imported to the workspace or used to
-           create a workspace object. list<SubAction> subactions - the
-           subactions taken as a part of this action. mapping<string, string>
-           custom - user definable custom provenance fields and their values.
-           string description - a free text description of this action.) ->
-           structure: parameter "time" of type "timestamp" (A time in the
-           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
-           (representing the UTC timezone) or the difference in time to UTC
-           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
-           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
-           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
-           of String, parameter "service" of String, parameter "service_ver"
-           of String, parameter "method" of String, parameter "method_params"
-           of list of unspecified object, parameter "script" of String,
-           parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           the user.) -> mapping from String to String, parameter "path" of
+           list of type "obj_ref" (A string that uniquely identifies an
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<ref_string> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. A reference path into the
+           object graph may be supplied. list<obj_ref> resolved_ws_objects -
+           the workspace objects ids from input_ws_objects resolved to
+           permanent workspace object references by the workspace service.
+           list<string> intermediate_incoming - if the previous action
+           produced output that 1) was not stored in a referrable way, and 2)
+           is used as input for this action, provide it with an arbitrary and
+           unique ID here, in the order of the input arguments to this
+           action. These IDs can be used in the method_params argument.
+           list<string> intermediate_outgoing - if this action produced
+           output that 1) was not stored in a referrable way, and 2) is used
+           as input for the next action, provide it with an arbitrary and
+           unique ID here, in the order of the output values from this
+           action. These IDs can be used in the intermediate_incoming
+           argument in the next action. list<ExternalDataUnit> external_data
+           - data external to the workspace that was either imported to the
+           workspace or used to create a workspace object. list<SubAction>
+           subactions - the subactions taken as a part of this action.
+           mapping<string, string> custom - user definable custom provenance
+           fields and their values. string description - a free text
+           description of this action.) -> structure: parameter "time" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "caller" of String, parameter "service"
+           of String, parameter "service_ver" of String, parameter "method"
+           of String, parameter "method_params" of list of unspecified
+           object, parameter "script" of String, parameter "script_ver" of
+           String, parameter "script_command_line" of String, parameter
+           "input_ws_objects" of list of type "ref_string" (A chain of
+           objects with references to one another as a string. A single
+           string that is semantically identical to ref_chain above.
+           Represents a path from one workspace object to another through an
+           arbitrarily number of intermediate objects where each object has a
+           dependency or provenance reference to the next object. Each entry
+           is an obj_ref as defined earlier. Entries are separated by
+           semicolons. Whitespace is ignored. Examples: 3/5/6;
+           kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -1496,37 +1497,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_objects',
@@ -1546,38 +1540,63 @@ class Workspace(object):
            references, and object_info for this object without the object
            data. Default false.) -> structure: parameter "objects" of list of
            type "ObjectSpecification" (An Object Specification (OS). Inherits
-           from ObjectIdentity. Specifies which object, and which parts of
-           that object, to retrieve from the Workspace Service. The fields
-           wsid, workspace, objid, name, ver, and ref are identical to the
-           ObjectIdentity fields. REFERENCE FOLLOWING: Reference following
-           guarantees that a user that has access to an object can always see
-           a) objects that are referenced inside the object and b) objects
-           that are referenced in the object's provenance. This ensures that
-           the user has visibility into the entire provenance of the object
-           and the object's object dependencies (e.g. references). The user
-           must have at least read access to the object specified in this SO,
-           but need not have access to any further objects in the reference
-           chain, and those objects may be deleted. Optional reference
-           following fields: ref_chain obj_path - a path to the desired
-           object from the object specified in this OS. In other words, the
-           object specified in this OS is assumed to be accessible to the
-           user, and the objects in the object path represent a chain of
-           references to the desired object at the end of the object path. If
-           the references are all valid, the desired object will be returned.
-           - OR - list<obj_ref> obj_ref_path - shorthand for the obj_path.
-           Only one of obj_path or obj_ref_path may be specified. OBJECT
-           SUBSETS: When selecting a subset of an array in an object, the
-           returned array is compressed to the size of the subset, but the
-           ordering of the array is maintained. For example, if the array
-           stored at the 'feature' key of a Genome object has 4000 entries,
-           and the object paths provided are: /feature/7 /feature/3015
-           /feature/700 The returned feature array will be of length three
-           and the entries will consist, in order, of the 7th, 700th, and
-           3015th entries of the original array. Optional object subset
-           fields: list<object_path> included - the portions of the object to
-           include in the object subset. boolean strict_maps - if true, throw
-           an exception if the subset specification traverses a non-existant
-           map key (default false) boolean strict_arrays - if true, throw an
+           from ObjectIdentity (OI). Specifies which object, and which parts
+           of that object, to retrieve from the Workspace Service. The fields
+           wsid, workspace, objid, name, and ver are identical to the OI
+           fields. The ref field's behavior is extended from OI. It maintains
+           its previous behavior, but now also can act as a reference string.
+           See reference following below for more information. REFERENCE
+           FOLLOWING: Reference following guarantees that a user that has
+           access to an object can always see a) objects that are referenced
+           inside the object and b) objects that are referenced in the
+           object's provenance. This ensures that the user has visibility
+           into the entire provenance of the object and the object's object
+           dependencies (e.g. references). The user must have at least read
+           access to the object specified in this SO, but need not have
+           access to any further objects in the reference chain, and those
+           objects may be deleted. Optional reference following fields: Note
+           that only one of the following fields may be specified. ref_chain
+           obj_path - a path to the desired object from the object specified
+           in this OS. In other words, the object specified in this OS is
+           assumed to be accessible to the user, and the objects in the
+           object path represent a chain of references to the desired object
+           at the end of the object path. If the references are all valid,
+           the desired object will be returned. - OR - list<obj_ref>
+           obj_ref_path - shorthand for the obj_path. - OR - ref_chain
+           to_obj_path - identical to obj_path, except that the path is TO
+           the object specified in this OS, rather than from the object. In
+           other words the object specified by wsid/objid/ref etc. is the end
+           of the path, and to_obj_path is the rest of the path. The user
+           must have access to the first object in the to_obj_path. - OR -
+           list<obj_ref> to_obj_ref_path - shorthand for the to_obj_path. -
+           OR - ref_string ref - A string representing a reference path from
+           one object to another. Unlike the previous reference following
+           options, the ref_string represents the ENTIRE path from the source
+           object to the target object. As with the OI object, the ref field
+           may contain a single reference. - OR - boolean find_refence_path -
+           This is the last, slowest, and most expensive resort for getting a
+           referenced object - do not use this method unless the path to the
+           object is unavailable by any other means. Setting the
+           find_refence_path parameter to true means that the workspace
+           service will search through the object reference graph from the
+           object specified in this OS to find an object that 1) the user can
+           access, and 2) has an unbroken reference path to the target
+           object. If the search succeeds, the object will be returned as
+           normal. Note that the search will automatically fail after a
+           certain (but much larger than necessary for the vast majority of
+           cases) number of objects are traversed. OBJECT SUBSETS: When
+           selecting a subset of an array in an object, the returned array is
+           compressed to the size of the subset, but the ordering of the
+           array is maintained. For example, if the array stored at the
+           'feature' key of a Genome object has 4000 entries, and the object
+           paths provided are: /feature/7 /feature/3015 /feature/700 The
+           returned feature array will be of length three and the entries
+           will consist, in order, of the 7th, 700th, and 3015th entries of
+           the original array. Optional object subset fields:
+           list<object_path> included - the portions of the object to include
+           in the object subset. boolean strict_maps - if true, throw an
+           exception if the subset specification traverses a non-existent map
+           key (default false) boolean strict_arrays - if true, throw an
            exception if the subset specification exceeds the size of an array
            (default true)) -> structure: parameter "workspace" of type
            "ws_name" (A string used as a name for a workspace. Any string
@@ -1591,31 +1610,68 @@ class Workspace(object):
            |._- that is not an integer is acceptable.), parameter "objid" of
            type "obj_id" (The unique, permanent numerical ID of an object.),
            parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "obj_path" of type "ref_chain" (A chain of objects with
+           references to one another. An object reference chain consists of a
+           list of objects where the nth object possesses a reference, either
+           in the object itself or in the object provenance, to the n+1th
+           object.) -> list of type "ObjectIdentity" (An object identifier.
+           Select an object by either: One, and only one, of the numerical id
+           or name of the workspace. ws_id wsid - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace. AND One,
+           and only one, of the numerical id or name of the object. obj_id
+           objid- the numerical ID of the object. obj_name name - name of the
+           object. OPTIONALLY obj_ver ver - the version of the object. OR an
+           object reference string: obj_ref ref - an object reference
+           string.) -> structure: parameter "workspace" of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "obj_path" of type "ref_chain" (A
-           chain of objects with references to one another. An object
-           reference chain consists of a list of objects where the nth object
-           possesses a reference, either in the object itself or in the
-           object provenance, to the n+1th object.) -> list of type
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "obj_ref_path" of list of type "obj_ref" (A string that uniquely
+           identifies an object in the workspace service. The format is
+           [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_path" of type
+           "ref_chain" (A chain of objects with references to one another. An
+           object reference chain consists of a list of objects where the nth
+           object possesses a reference, either in the object itself or in
+           the object provenance, to the n+1th object.) -> list of type
            "ObjectIdentity" (An object identifier. Select an object by
            either: One, and only one, of the numerical id or name of the
-           workspace, where the name can also be a KBase ID including the
-           numerical id, e.g. kb|ws.35. ws_id wsid - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. AND One, and only
-           one, of the numerical id or name of the object. obj_id objid- the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
            numerical ID of the object. obj_name name - name of the object.
            OPTIONALLY obj_ver ver - the version of the object. OR an object
            reference string: obj_ref ref - an object reference string.) ->
@@ -1632,62 +1688,58 @@ class Workspace(object):
            unique, permanent numerical ID of an object.), parameter "ver" of
            type "obj_ver" (An object version. The version of the object,
            starting at 1.), parameter "ref" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "obj_ref_path" of list of type
-           "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "included" of list of type
-           "object_path" (A path into an object. Identify a sub portion of an
-           object by providing the path, delimited by a slash (/), to that
-           portion of the object. Thus the path may not have slashes in the
-           structure or mapping keys. Examples: /foo/bar/3 - specifies the
-           bar key of the foo mapping and the 3rd entry of the array if bar
-           maps to an array or the value mapped to the string "3" if bar maps
-           to a map. /foo/bar/[*]/baz - specifies the baz field of all the
-           objects in the list mapped by the bar key in the map foo.
-           /foo/asterisk/baz - specifies the baz field of all the objects in
-           the values of the foo mapping. Swap 'asterisk' for * in the path.
-           In case you need to use '/' or '~' in path items use JSON Pointer
-           notation defined here: http://tools.ietf.org/html/rfc6901),
-           parameter "strict_maps" of type "boolean" (A boolean. 0 = false,
-           other = true.), parameter "strict_arrays" of type "boolean" (A
-           boolean. 0 = false, other = true.), parameter "ignoreErrors" of
-           type "boolean" (A boolean. 0 = false, other = true.), parameter
-           "no_data" of type "boolean" (A boolean. 0 = false, other = true.)
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_ref_path" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. The format is [ws_name or id]/[obj_name or
+           id]/[obj_ver]. For example, MyFirstWorkspace/MyFirstObject/3 would
+           identify the third version of an object called MyFirstObject in
+           the workspace called MyFirstWorkspace. 42/Panic/1 would identify
+           the first version of the object name Panic in workspace with id
+           42. Towel/1/6 would identify the 6th version of the object with id
+           1 in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "find_reference_path" of type "boolean" (A boolean. 0 = false,
+           other = true.), parameter "included" of list of type "object_path"
+           (A path into an object. Identify a sub portion of an object by
+           providing the path, delimited by a slash (/), to that portion of
+           the object. Thus the path may not have slashes in the structure or
+           mapping keys. Examples: /foo/bar/3 - specifies the bar key of the
+           foo mapping and the 3rd entry of the array if bar maps to an array
+           or the value mapped to the string "3" if bar maps to a map.
+           /foo/bar/[*]/baz - specifies the baz field of all the objects in
+           the list mapped by the bar key in the map foo. /foo/asterisk/baz -
+           specifies the baz field of all the objects in the values of the
+           foo mapping. Swap 'asterisk' for * in the path. In case you need
+           to use '/' or '~' in path items use JSON Pointer notation defined
+           here: http://tools.ietf.org/html/rfc6901), parameter "strict_maps"
+           of type "boolean" (A boolean. 0 = false, other = true.), parameter
+           "strict_arrays" of type "boolean" (A boolean. 0 = false, other =
+           true.), parameter "ignoreErrors" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "no_data" of type "boolean" (A
+           boolean. 0 = false, other = true.)
         :returns: instance of type "GetObjects2Results" (Results from the
            get_objects2 function. list<ObjectData> data - the returned
            objects.) -> structure: parameter "data" of list of type
            "ObjectData" (The data and supplemental info for an object.
            UnspecifiedObject data - the object's data or subset data.
-           object_info info - information about the object.
+           object_info info - information about the object. list<obj_ref>
+           path - the path to the object through the object reference graph.
+           All the references in the path are absolute.
            list<ProvenanceAction> provenance - the object's provenance.
            username creator - the user that first saved the object to the
            workspace. ws_id orig_wsid - the id of the workspace in which this
            object was originally saved. Missing for objects saved prior to
            version 0.4.1. timestamp created - the date the object was first
            saved to the workspace. epoch epoch - the date the object was
-           first saved to the workspace. list<obj_ref> - the references
+           first saved to the workspace. list<obj_ref> refs - the references
            contained within the object. obj_ref copied - the reference of the
            source object if this object is a copy and the copy source exists
            and is accessible. null otherwise. boolean
@@ -1741,97 +1793,101 @@ class Workspace(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
-           list<ExternalDataUnit> external_data - data external to the
-           workspace that was either imported to the workspace or used to
-           create a workspace object. list<SubAction> subactions - the
-           subactions taken as a part of this action. mapping<string, string>
-           custom - user definable custom provenance fields and their values.
-           string description - a free text description of this action.) ->
-           structure: parameter "time" of type "timestamp" (A time in the
-           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
-           (representing the UTC timezone) or the difference in time to UTC
-           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
-           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
-           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
-           of String, parameter "service" of String, parameter "service_ver"
-           of String, parameter "method" of String, parameter "method_params"
-           of list of unspecified object, parameter "script" of String,
-           parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           the user.) -> mapping from String to String, parameter "path" of
+           list of type "obj_ref" (A string that uniquely identifies an
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<ref_string> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. A reference path into the
+           object graph may be supplied. list<obj_ref> resolved_ws_objects -
+           the workspace objects ids from input_ws_objects resolved to
+           permanent workspace object references by the workspace service.
+           list<string> intermediate_incoming - if the previous action
+           produced output that 1) was not stored in a referrable way, and 2)
+           is used as input for this action, provide it with an arbitrary and
+           unique ID here, in the order of the input arguments to this
+           action. These IDs can be used in the method_params argument.
+           list<string> intermediate_outgoing - if this action produced
+           output that 1) was not stored in a referrable way, and 2) is used
+           as input for the next action, provide it with an arbitrary and
+           unique ID here, in the order of the output values from this
+           action. These IDs can be used in the intermediate_incoming
+           argument in the next action. list<ExternalDataUnit> external_data
+           - data external to the workspace that was either imported to the
+           workspace or used to create a workspace object. list<SubAction>
+           subactions - the subactions taken as a part of this action.
+           mapping<string, string> custom - user definable custom provenance
+           fields and their values. string description - a free text
+           description of this action.) -> structure: parameter "time" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "caller" of String, parameter "service"
+           of String, parameter "service_ver" of String, parameter "method"
+           of String, parameter "method_params" of list of unspecified
+           object, parameter "script" of String, parameter "script_ver" of
+           String, parameter "script_command_line" of String, parameter
+           "input_ws_objects" of list of type "ref_string" (A chain of
+           objects with references to one another as a string. A single
+           string that is semantically identical to ref_chain above.
+           Represents a path from one workspace object to another through an
+           arbitrarily number of intermediate objects where each object has a
+           dependency or provenance reference to the next object. Each entry
+           is an obj_ref as defined earlier. Entries are separated by
+           semicolons. Whitespace is ignored. Examples: 3/5/6;
+           kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -1886,37 +1942,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_objects2',
@@ -1941,11 +1990,9 @@ class Workspace(object):
         :param sub_object_ids: instance of list of type "SubObjectIdentity"
            (DEPRECATED An object subset identifier. Select a subset of an
            object by: EITHER One, and only one, of the numerical id or name
-           of the workspace, where the name can also be a KBase ID including
-           the numerical id, e.g. kb|ws.35. ws_id wsid - the numerical ID of
-           the workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. AND One, and only
-           one, of the numerical id or name of the object. obj_id objid- the
+           of the workspace. ws_id wsid - the numerical ID of the workspace.
+           ws_name workspace - name of the workspace. AND One, and only one,
+           of the numerical id or name of the object. obj_id objid- the
            numerical ID of the object. obj_name name - name of the object.
            OPTIONALLY obj_ver ver - the version of the object. OR an object
            reference string: obj_ref ref - an object reference string. AND a
@@ -1969,44 +2016,43 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "included" of list of type
-           "object_path" (A path into an object. Identify a sub portion of an
-           object by providing the path, delimited by a slash (/), to that
-           portion of the object. Thus the path may not have slashes in the
-           structure or mapping keys. Examples: /foo/bar/3 - specifies the
-           bar key of the foo mapping and the 3rd entry of the array if bar
-           maps to an array or the value mapped to the string "3" if bar maps
-           to a map. /foo/bar/[*]/baz - specifies the baz field of all the
-           objects in the list mapped by the bar key in the map foo.
-           /foo/asterisk/baz - specifies the baz field of all the objects in
-           the values of the foo mapping. Swap 'asterisk' for * in the path.
-           In case you need to use '/' or '~' in path items use JSON Pointer
-           notation defined here: http://tools.ietf.org/html/rfc6901),
-           parameter "strict_maps" of type "boolean" (A boolean. 0 = false,
-           other = true.), parameter "strict_arrays" of type "boolean" (A
-           boolean. 0 = false, other = true.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter "included" of
+           list of type "object_path" (A path into an object. Identify a sub
+           portion of an object by providing the path, delimited by a slash
+           (/), to that portion of the object. Thus the path may not have
+           slashes in the structure or mapping keys. Examples: /foo/bar/3 -
+           specifies the bar key of the foo mapping and the 3rd entry of the
+           array if bar maps to an array or the value mapped to the string
+           "3" if bar maps to a map. /foo/bar/[*]/baz - specifies the baz
+           field of all the objects in the list mapped by the bar key in the
+           map foo. /foo/asterisk/baz - specifies the baz field of all the
+           objects in the values of the foo mapping. Swap 'asterisk' for * in
+           the path. In case you need to use '/' or '~' in path items use
+           JSON Pointer notation defined here:
+           http://tools.ietf.org/html/rfc6901), parameter "strict_maps" of
+           type "boolean" (A boolean. 0 = false, other = true.), parameter
+           "strict_arrays" of type "boolean" (A boolean. 0 = false, other =
+           true.)
         :returns: instance of list of type "ObjectData" (The data and
            supplemental info for an object. UnspecifiedObject data - the
            object's data or subset data. object_info info - information about
-           the object. list<ProvenanceAction> provenance - the object's
+           the object. list<obj_ref> path - the path to the object through
+           the object reference graph. All the references in the path are
+           absolute. list<ProvenanceAction> provenance - the object's
            provenance. username creator - the user that first saved the
            object to the workspace. ws_id orig_wsid - the id of the workspace
            in which this object was originally saved. Missing for objects
            saved prior to version 0.4.1. timestamp created - the date the
            object was first saved to the workspace. epoch epoch - the date
-           the object was first saved to the workspace. list<obj_ref> - the
-           references contained within the object. obj_ref copied - the
+           the object was first saved to the workspace. list<obj_ref> refs -
+           the references contained within the object. obj_ref copied - the
            reference of the source object if this object is a copy and the
            copy source exists and is accessible. null otherwise. boolean
            copy_source_inaccessible - true if the object was copied from
@@ -2059,97 +2105,101 @@ class Workspace(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
-           list<ExternalDataUnit> external_data - data external to the
-           workspace that was either imported to the workspace or used to
-           create a workspace object. list<SubAction> subactions - the
-           subactions taken as a part of this action. mapping<string, string>
-           custom - user definable custom provenance fields and their values.
-           string description - a free text description of this action.) ->
-           structure: parameter "time" of type "timestamp" (A time in the
-           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
-           (representing the UTC timezone) or the difference in time to UTC
-           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
-           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
-           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
-           of String, parameter "service" of String, parameter "service_ver"
-           of String, parameter "method" of String, parameter "method_params"
-           of list of unspecified object, parameter "script" of String,
-           parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           the user.) -> mapping from String to String, parameter "path" of
+           list of type "obj_ref" (A string that uniquely identifies an
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<ref_string> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. A reference path into the
+           object graph may be supplied. list<obj_ref> resolved_ws_objects -
+           the workspace objects ids from input_ws_objects resolved to
+           permanent workspace object references by the workspace service.
+           list<string> intermediate_incoming - if the previous action
+           produced output that 1) was not stored in a referrable way, and 2)
+           is used as input for this action, provide it with an arbitrary and
+           unique ID here, in the order of the input arguments to this
+           action. These IDs can be used in the method_params argument.
+           list<string> intermediate_outgoing - if this action produced
+           output that 1) was not stored in a referrable way, and 2) is used
+           as input for the next action, provide it with an arbitrary and
+           unique ID here, in the order of the output values from this
+           action. These IDs can be used in the intermediate_incoming
+           argument in the next action. list<ExternalDataUnit> external_data
+           - data external to the workspace that was either imported to the
+           workspace or used to create a workspace object. list<SubAction>
+           subactions - the subactions taken as a part of this action.
+           mapping<string, string> custom - user definable custom provenance
+           fields and their values. string description - a free text
+           description of this action.) -> structure: parameter "time" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "caller" of String, parameter "service"
+           of String, parameter "service_ver" of String, parameter "method"
+           of String, parameter "method_params" of list of unspecified
+           object, parameter "script" of String, parameter "script_ver" of
+           String, parameter "script_command_line" of String, parameter
+           "input_ws_objects" of list of type "ref_string" (A chain of
+           objects with references to one another as a string. A single
+           string that is semantically identical to ref_chain above.
+           Represents a path from one workspace object to another through an
+           arbitrarily number of intermediate objects where each object has a
+           dependency or provenance reference to the next object. Each entry
+           is an obj_ref as defined earlier. Entries are separated by
+           semicolons. Whitespace is ignored. Examples: 3/5/6;
+           kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -2204,37 +2254,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_object_subset',
@@ -2246,19 +2289,17 @@ class Workspace(object):
         ignored.
         :param object: instance of type "ObjectIdentity" (An object
            identifier. Select an object by either: One, and only one, of the
-           numerical id or name of the workspace, where the name can also be
-           a KBase ID including the numerical id, e.g. kb|ws.35. ws_id wsid -
-           the numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78. AND
-           One, and only one, of the numerical id or name of the object.
-           obj_id objid- the numerical ID of the object. obj_name name - name
-           of the object. OPTIONALLY obj_ver ver - the version of the object.
-           OR an object reference string: obj_ref ref - an object reference
-           string.) -> structure: parameter "workspace" of type "ws_name" (A
-           string used as a name for a workspace. Any string consisting of
-           alphanumeric characters and "_", ".", or "-" that is not an
-           integer is acceptable. The name may optionally be prefixed with
-           the workspace owner's user name and a colon, e.g.
+           numerical id or name of the workspace. ws_id wsid - the numerical
+           ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
+           the object. obj_id objid- the numerical ID of the object. obj_name
+           name - name of the object. OPTIONALLY obj_ver ver - the version of
+           the object. OR an object reference string: obj_ref ref - an object
+           reference string.) -> structure: parameter "workspace" of type
+           "ws_name" (A string used as a name for a workspace. Any string
+           consisting of alphanumeric characters and "_", ".", or "-" that is
+           not an integer is acceptable. The name may optionally be prefixed
+           with the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
            unique, permanent numerical ID of a workspace.), parameter "name"
            of type "obj_name" (A string used as a name for an object. Any
@@ -2268,18 +2309,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of type "object_info" (Information about
            an object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -2335,11 +2372,9 @@ class Workspace(object):
         in the deleted state are not returned.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -2357,18 +2392,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of list of type "object_info" (Information
            about an object, including user provided metadata. obj_id objid -
            the numerical id of the object. obj_name name - the name of the
@@ -2428,11 +2459,9 @@ class Workspace(object):
         @deprecated
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -2450,18 +2479,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of Long
         """
         return self._client.call_method(
@@ -2492,19 +2517,17 @@ class Workspace(object):
            reference, either in the object itself or in the object
            provenance, to the n+1th object.) -> list of type "ObjectIdentity"
            (An object identifier. Select an object by either: One, and only
-           one, of the numerical id or name of the workspace, where the name
-           can also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
-           the object. obj_id objid- the numerical ID of the object. obj_name
-           name - name of the object. OPTIONALLY obj_ver ver - the version of
-           the object. OR an object reference string: obj_ref ref - an object
-           reference string.) -> structure: parameter "workspace" of type
-           "ws_name" (A string used as a name for a workspace. Any string
-           consisting of alphanumeric characters and "_", ".", or "-" that is
-           not an integer is acceptable. The name may optionally be prefixed
-           with the workspace owner's user name and a colon, e.g.
+           one, of the numerical id or name of the workspace. ws_id wsid -
+           the numerical ID of the workspace. ws_name workspace - the name of
+           the workspace. AND One, and only one, of the numerical id or name
+           of the object. obj_id objid- the numerical ID of the object.
+           obj_name name - name of the object. OPTIONALLY obj_ver ver - the
+           version of the object. OR an object reference string: obj_ref ref
+           - an object reference string.) -> structure: parameter "workspace"
+           of type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
            unique, permanent numerical ID of a workspace.), parameter "name"
            of type "obj_name" (A string used as a name for an object. Any
@@ -2514,29 +2537,27 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of type "ObjectData" (The data and
            supplemental info for an object. UnspecifiedObject data - the
            object's data or subset data. object_info info - information about
-           the object. list<ProvenanceAction> provenance - the object's
+           the object. list<obj_ref> path - the path to the object through
+           the object reference graph. All the references in the path are
+           absolute. list<ProvenanceAction> provenance - the object's
            provenance. username creator - the user that first saved the
            object to the workspace. ws_id orig_wsid - the id of the workspace
            in which this object was originally saved. Missing for objects
            saved prior to version 0.4.1. timestamp created - the date the
            object was first saved to the workspace. epoch epoch - the date
-           the object was first saved to the workspace. list<obj_ref> - the
-           references contained within the object. obj_ref copied - the
+           the object was first saved to the workspace. list<obj_ref> refs -
+           the references contained within the object. obj_ref copied - the
            reference of the source object if this object is a copy and the
            copy source exists and is accessible. null otherwise. boolean
            copy_source_inaccessible - true if the object was copied from
@@ -2589,97 +2610,101 @@ class Workspace(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
-           list<ExternalDataUnit> external_data - data external to the
-           workspace that was either imported to the workspace or used to
-           create a workspace object. list<SubAction> subactions - the
-           subactions taken as a part of this action. mapping<string, string>
-           custom - user definable custom provenance fields and their values.
-           string description - a free text description of this action.) ->
-           structure: parameter "time" of type "timestamp" (A time in the
-           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
-           (representing the UTC timezone) or the difference in time to UTC
-           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
-           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
-           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
-           of String, parameter "service" of String, parameter "service_ver"
-           of String, parameter "method" of String, parameter "method_params"
-           of list of unspecified object, parameter "script" of String,
-           parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           the user.) -> mapping from String to String, parameter "path" of
+           list of type "obj_ref" (A string that uniquely identifies an
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<ref_string> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. A reference path into the
+           object graph may be supplied. list<obj_ref> resolved_ws_objects -
+           the workspace objects ids from input_ws_objects resolved to
+           permanent workspace object references by the workspace service.
+           list<string> intermediate_incoming - if the previous action
+           produced output that 1) was not stored in a referrable way, and 2)
+           is used as input for this action, provide it with an arbitrary and
+           unique ID here, in the order of the input arguments to this
+           action. These IDs can be used in the method_params argument.
+           list<string> intermediate_outgoing - if this action produced
+           output that 1) was not stored in a referrable way, and 2) is used
+           as input for the next action, provide it with an arbitrary and
+           unique ID here, in the order of the output values from this
+           action. These IDs can be used in the intermediate_incoming
+           argument in the next action. list<ExternalDataUnit> external_data
+           - data external to the workspace that was either imported to the
+           workspace or used to create a workspace object. list<SubAction>
+           subactions - the subactions taken as a part of this action.
+           mapping<string, string> custom - user definable custom provenance
+           fields and their values. string description - a free text
+           description of this action.) -> structure: parameter "time" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "caller" of String, parameter "service"
+           of String, parameter "service_ver" of String, parameter "method"
+           of String, parameter "method_params" of list of unspecified
+           object, parameter "script" of String, parameter "script_ver" of
+           String, parameter "script_command_line" of String, parameter
+           "input_ws_objects" of list of type "ref_string" (A chain of
+           objects with references to one another as a string. A single
+           string that is semantically identical to ref_chain above.
+           Represents a path from one workspace object to another through an
+           arbitrarily number of intermediate objects where each object has a
+           dependency or provenance reference to the next object. Each entry
+           is an obj_ref as defined earlier. Entries are separated by
+           semicolons. Whitespace is ignored. Examples: 3/5/6;
+           kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -2734,37 +2759,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_referenced_objects',
@@ -2872,26 +2890,28 @@ class Workspace(object):
            about a workspace. ws_id id - the numerical ID of the workspace.
            ws_name workspace - name of the workspace. username owner - name
            of the user who owns (e.g. created) this workspace. timestamp
-           moddate - date when the workspace was last modified. int objects -
-           the number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           moddate - date when the workspace was last modified. int max_objid
+           - the maximum object ID appearing in this workspace. Since cloning
+           a workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -2959,29 +2979,30 @@ class Workspace(object):
            Always returns the empty string. string chsum - the md5 checksum
            of the object. usermeta metadata - arbitrary user-supplied
            metadata about the object. obj_id objid - the numerical id of the
-           object.) -> tuple of size 12: parameter "id" of type "obj_name" (A
-           string used as a name for an object. Any string consisting of
-           alphanumeric characters and the characters |._- that is not an
-           integer is acceptable.), parameter "type" of type "type_string" (A
-           type string. Specifies the type and its version in a single string
-           in the format [module].[typename]-[major].[minor]: module - a
-           string. The module name of the typespec containing the type.
-           typename - a string. The name of the type as assigned by the
-           typedef statement. major - an integer. The major version of the
-           type. A change in the major version implies the type has changed
-           in a non-backwards compatible way. minor - an integer. The minor
-           version of the type. A change in the minor version implies that
-           the type has changed in a way that is backwards compatible with
-           previous type definitions. In many cases, the major and minor
-           versions are optional, and if not provided the most recent version
-           will be used. Example: MyModule.MyType-3.1), parameter "moddate"
-           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
-           where Z is either the character Z (representing the UTC timezone)
-           or the difference in time to UTC in the format +/-HHMM, eg:
-           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "instance" of
-           Long, parameter "command" of String, parameter "lastmodifier" of
-           type "username" (Login name of a KBase user account.), parameter
+           object. @deprecated object_info) -> tuple of size 12: parameter
+           "id" of type "obj_name" (A string used as a name for an object.
+           Any string consisting of alphanumeric characters and the
+           characters |._- that is not an integer is acceptable.), parameter
+           "type" of type "type_string" (A type string. Specifies the type
+           and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "moddate" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "instance" of Long,
+           parameter "command" of String, parameter "lastmodifier" of type
+           "username" (Login name of a KBase user account.), parameter
            "owner" of type "username" (Login name of a KBase user account.),
            parameter "workspace" of type "ws_name" (A string used as a name
            for a workspace. Any string consisting of alphanumeric characters
@@ -3006,49 +3027,47 @@ class Workspace(object):
            must be provided. It is strongly recommended that the list is
            restricted to the workspaces of interest, or the results may be
            very large: list<ws_id> ids - the numerical IDs of the workspaces
-           of interest. list<ws_name> workspaces - names of the workspaces of
-           interest or the workspace IDs in KBase format, e.g. kb|ws.78.
-           type_string type - type of the objects to be listed.  Here,
-           omitting version information will find any objects that match the
-           provided type - e.g. Foo.Bar-0 will match Foo.Bar-0.X where X is
-           any existing version. Only one of each timestamp/epoch pair may be
-           supplied. Optional arguments: permission perm - filter objects by
-           minimum permission level. 'None' and 'readable' are ignored.
-           list<username> savedby - filter objects by the user that saved or
-           copied the object. usermeta meta - filter objects by the user
-           supplied metadata. NOTE: only one key/value pair is supported at
-           this time. A full map is provided as input for the possibility for
-           expansion in the future. timestamp after - only return objects
-           that were created after this date. timestamp before - only return
-           objects that were created before this date. epoch after_epoch -
-           only return objects that were created after this date. epoch
-           before_epoch - only return objects that were created before this
-           date. obj_id minObjectID - only return objects with an object id
-           greater or equal to this value. obj_id maxObjectID - only return
-           objects with an object id less than or equal to this value.
-           boolean showDeleted - show deleted objects in workspaces to which
-           the user has write access. boolean showOnlyDeleted - only show
+           of interest. list<ws_name> workspaces - the names of the
+           workspaces of interest. type_string type - type of the objects to
+           be listed.  Here, omitting version information will find any
+           objects that match the provided type - e.g. Foo.Bar-0 will match
+           Foo.Bar-0.X where X is any existing version. Only one of each
+           timestamp/epoch pair may be supplied. Optional arguments:
+           permission perm - filter objects by minimum permission level.
+           'None' and 'readable' are ignored. list<username> savedby - filter
+           objects by the user that saved or copied the object. usermeta meta
+           - filter objects by the user supplied metadata. NOTE: only one
+           key/value pair is supported at this time. A full map is provided
+           as input for the possibility for expansion in the future.
+           timestamp after - only return objects that were created after this
+           date. timestamp before - only return objects that were created
+           before this date. epoch after_epoch - only return objects that
+           were created after this date. epoch before_epoch - only return
+           objects that were created before this date. obj_id minObjectID -
+           only return objects with an object id greater or equal to this
+           value. obj_id maxObjectID - only return objects with an object id
+           less than or equal to this value. boolean showDeleted - show
            deleted objects in workspaces to which the user has write access.
-           boolean showHidden - show hidden objects. boolean showAllVersions
-           - show all versions of each object that match the filters rather
-           than only the most recent version. boolean includeMetadata -
-           include the user provided metadata in the returned object_info. If
-           false (0 or null), the default, the metadata will be null. boolean
+           boolean showOnlyDeleted - only show deleted objects in workspaces
+           to which the user has write access. boolean showHidden - show
+           hidden objects. boolean showAllVersions - show all versions of
+           each object that match the filters rather than only the most
+           recent version. boolean includeMetadata - include the user
+           provided metadata in the returned object_info. If false (0 or
+           null), the default, the metadata will be null. boolean
            excludeGlobal - exclude objects in global workspaces. This
            parameter only has an effect when filtering by types alone. int
-           skip - DEPRECATED. Skip the first X objects. Maximum value is
-           2^31, skip values < 0 are treated as 0, the default. int limit -
-           limit the output to X objects. Default and maximum value is 10000.
-           Limit values < 1 are treated as 10000, the default.) -> structure:
-           parameter "workspaces" of list of type "ws_name" (A string used as
-           a name for a workspace. Any string consisting of alphanumeric
-           characters and "_", ".", or "-" that is not an integer is
-           acceptable. The name may optionally be prefixed with the workspace
-           owner's user name and a colon, e.g. kbasetest:my_workspace.),
-           parameter "ids" of list of type "ws_id" (The unique, permanent
-           numerical ID of a workspace.), parameter "type" of type
-           "type_string" (A type string. Specifies the type and its version
-           in a single string in the format
+           limit - limit the output to X objects. Default and maximum value
+           is 10000. Limit values < 1 are treated as 10000, the default.) ->
+           structure: parameter "workspaces" of list of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "ids" of list of type "ws_id"
+           (The unique, permanent numerical ID of a workspace.), parameter
+           "type" of type "type_string" (A type string. Specifies the type
+           and its version in a single string in the format
            [module].[typename]-[major].[minor]: module - a string. The module
            name of the typespec containing the type. typename - a string. The
            name of the type as assigned by the typedef statement. major - an
@@ -3090,8 +3109,7 @@ class Workspace(object):
            "boolean" (A boolean. 0 = false, other = true.), parameter
            "includeMetadata" of type "boolean" (A boolean. 0 = false, other =
            true.), parameter "excludeGlobal" of type "boolean" (A boolean. 0
-           = false, other = true.), parameter "skip" of Long, parameter
-           "limit" of Long
+           = false, other = true.), parameter "limit" of Long
         :returns: instance of list of type "object_info" (Information about
            an object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -3146,7 +3164,7 @@ class Workspace(object):
         Retrieves the metadata for a specified object from the specified
         workspace. Provides access to metadata for all versions of the object
         via the instance parameter. Provided for backwards compatibility.
-        @deprecated Workspace.get_object_info
+        @deprecated Workspace.get_object_info3
         :param params: instance of type "get_objectmeta_params" (Input
            parameters for the "get_objectmeta" function. Required arguments:
            ws_name workspace - name of the workspace containing the object
@@ -3179,22 +3197,23 @@ class Workspace(object):
            the object is stored string ref - Deprecated. Always returns the
            empty string. string chsum - the md5 checksum of the object.
            usermeta metadata - arbitrary user-supplied metadata about the
-           object. obj_id objid - the numerical id of the object.) -> tuple
-           of size 12: parameter "id" of type "obj_name" (A string used as a
-           name for an object. Any string consisting of alphanumeric
-           characters and the characters |._- that is not an integer is
-           acceptable.), parameter "type" of type "type_string" (A type
-           string. Specifies the type and its version in a single string in
-           the format [module].[typename]-[major].[minor]: module - a string.
-           The module name of the typespec containing the type. typename - a
-           string. The name of the type as assigned by the typedef statement.
-           major - an integer. The major version of the type. A change in the
-           major version implies the type has changed in a non-backwards
-           compatible way. minor - an integer. The minor version of the type.
-           A change in the minor version implies that the type has changed in
-           a way that is backwards compatible with previous type definitions.
-           In many cases, the major and minor versions are optional, and if
-           not provided the most recent version will be used. Example:
+           object. obj_id objid - the numerical id of the object. @deprecated
+           object_info) -> tuple of size 12: parameter "id" of type
+           "obj_name" (A string used as a name for an object. Any string
+           consisting of alphanumeric characters and the characters |._- that
+           is not an integer is acceptable.), parameter "type" of type
+           "type_string" (A type string. Specifies the type and its version
+           in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
            MyModule.MyType-3.1), parameter "moddate" of type "timestamp" (A
            time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
            character Z (representing the UTC timezone) or the difference in
@@ -3226,14 +3245,12 @@ class Workspace(object):
         Otherwise the metadata in the object_info will be null.
         This method will be replaced by the behavior of get_object_info_new
         in the future.
-        @deprecated Workspace.get_object_info_new
+        @deprecated Workspace.get_object_info3
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -3251,18 +3268,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :param includeMetadata: instance of type "boolean" (A boolean. 0 =
            false, other = true.)
         :returns: instance of list of type "object_info" (Information about
@@ -3317,6 +3330,7 @@ class Workspace(object):
     def get_object_info_new(self, params, context=None):
         """
         Get information about objects from the workspace.
+        @deprecated Workspace.get_object_info3
         :param params: instance of type "GetObjectInfoNewParams" (Input
            parameters for the "get_object_info_new" function. Required
            arguments: list<ObjectSpecification> objects - the objects for
@@ -3325,79 +3339,141 @@ class Workspace(object):
            includeMetadata - include the object metadata in the returned
            information. Default false. boolean ignoreErrors - Don't throw an
            exception if an object cannot be accessed; return null for that
-           object's information instead. Default false.) -> structure:
-           parameter "objects" of list of type "ObjectSpecification" (An
-           Object Specification (OS). Inherits from ObjectIdentity. Specifies
-           which object, and which parts of that object, to retrieve from the
-           Workspace Service. The fields wsid, workspace, objid, name, ver,
-           and ref are identical to the ObjectIdentity fields. REFERENCE
-           FOLLOWING: Reference following guarantees that a user that has
-           access to an object can always see a) objects that are referenced
-           inside the object and b) objects that are referenced in the
-           object's provenance. This ensures that the user has visibility
-           into the entire provenance of the object and the object's object
-           dependencies (e.g. references). The user must have at least read
-           access to the object specified in this SO, but need not have
-           access to any further objects in the reference chain, and those
-           objects may be deleted. Optional reference following fields:
+           object's information instead. Default false. @deprecated
+           Workspace.GetObjectInfo3Params) -> structure: parameter "objects"
+           of list of type "ObjectSpecification" (An Object Specification
+           (OS). Inherits from ObjectIdentity (OI). Specifies which object,
+           and which parts of that object, to retrieve from the Workspace
+           Service. The fields wsid, workspace, objid, name, and ver are
+           identical to the OI fields. The ref field's behavior is extended
+           from OI. It maintains its previous behavior, but now also can act
+           as a reference string. See reference following below for more
+           information. REFERENCE FOLLOWING: Reference following guarantees
+           that a user that has access to an object can always see a) objects
+           that are referenced inside the object and b) objects that are
+           referenced in the object's provenance. This ensures that the user
+           has visibility into the entire provenance of the object and the
+           object's object dependencies (e.g. references). The user must have
+           at least read access to the object specified in this SO, but need
+           not have access to any further objects in the reference chain, and
+           those objects may be deleted. Optional reference following fields:
+           Note that only one of the following fields may be specified.
            ref_chain obj_path - a path to the desired object from the object
            specified in this OS. In other words, the object specified in this
            OS is assumed to be accessible to the user, and the objects in the
            object path represent a chain of references to the desired object
            at the end of the object path. If the references are all valid,
            the desired object will be returned. - OR - list<obj_ref>
-           obj_ref_path - shorthand for the obj_path. Only one of obj_path or
-           obj_ref_path may be specified. OBJECT SUBSETS: When selecting a
-           subset of an array in an object, the returned array is compressed
-           to the size of the subset, but the ordering of the array is
-           maintained. For example, if the array stored at the 'feature' key
-           of a Genome object has 4000 entries, and the object paths provided
-           are: /feature/7 /feature/3015 /feature/700 The returned feature
-           array will be of length three and the entries will consist, in
-           order, of the 7th, 700th, and 3015th entries of the original
-           array. Optional object subset fields: list<object_path> included -
-           the portions of the object to include in the object subset.
-           boolean strict_maps - if true, throw an exception if the subset
-           specification traverses a non-existant map key (default false)
-           boolean strict_arrays - if true, throw an exception if the subset
-           specification exceeds the size of an array (default true)) ->
-           structure: parameter "workspace" of type "ws_name" (A string used
-           as a name for a workspace. Any string consisting of alphanumeric
-           characters and "_", ".", or "-" that is not an integer is
-           acceptable. The name may optionally be prefixed with the workspace
-           owner's user name and a colon, e.g. kbasetest:my_workspace.),
-           parameter "wsid" of type "ws_id" (The unique, permanent numerical
-           ID of a workspace.), parameter "name" of type "obj_name" (A string
-           used as a name for an object. Any string consisting of
-           alphanumeric characters and the characters |._- that is not an
-           integer is acceptable.), parameter "objid" of type "obj_id" (The
-           unique, permanent numerical ID of an object.), parameter "ver" of
-           type "obj_ver" (An object version. The version of the object,
-           starting at 1.), parameter "ref" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           obj_ref_path - shorthand for the obj_path. - OR - ref_chain
+           to_obj_path - identical to obj_path, except that the path is TO
+           the object specified in this OS, rather than from the object. In
+           other words the object specified by wsid/objid/ref etc. is the end
+           of the path, and to_obj_path is the rest of the path. The user
+           must have access to the first object in the to_obj_path. - OR -
+           list<obj_ref> to_obj_ref_path - shorthand for the to_obj_path. -
+           OR - ref_string ref - A string representing a reference path from
+           one object to another. Unlike the previous reference following
+           options, the ref_string represents the ENTIRE path from the source
+           object to the target object. As with the OI object, the ref field
+           may contain a single reference. - OR - boolean find_refence_path -
+           This is the last, slowest, and most expensive resort for getting a
+           referenced object - do not use this method unless the path to the
+           object is unavailable by any other means. Setting the
+           find_refence_path parameter to true means that the workspace
+           service will search through the object reference graph from the
+           object specified in this OS to find an object that 1) the user can
+           access, and 2) has an unbroken reference path to the target
+           object. If the search succeeds, the object will be returned as
+           normal. Note that the search will automatically fail after a
+           certain (but much larger than necessary for the vast majority of
+           cases) number of objects are traversed. OBJECT SUBSETS: When
+           selecting a subset of an array in an object, the returned array is
+           compressed to the size of the subset, but the ordering of the
+           array is maintained. For example, if the array stored at the
+           'feature' key of a Genome object has 4000 entries, and the object
+           paths provided are: /feature/7 /feature/3015 /feature/700 The
+           returned feature array will be of length three and the entries
+           will consist, in order, of the 7th, 700th, and 3015th entries of
+           the original array. Optional object subset fields:
+           list<object_path> included - the portions of the object to include
+           in the object subset. boolean strict_maps - if true, throw an
+           exception if the subset specification traverses a non-existent map
+           key (default false) boolean strict_arrays - if true, throw an
+           exception if the subset specification exceeds the size of an array
+           (default true)) -> structure: parameter "workspace" of type
+           "ws_name" (A string used as a name for a workspace. Any string
+           consisting of alphanumeric characters and "_", ".", or "-" that is
+           not an integer is acceptable. The name may optionally be prefixed
+           with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "obj_path" of type "ref_chain" (A chain of objects with
+           references to one another. An object reference chain consists of a
+           list of objects where the nth object possesses a reference, either
+           in the object itself or in the object provenance, to the n+1th
+           object.) -> list of type "ObjectIdentity" (An object identifier.
+           Select an object by either: One, and only one, of the numerical id
+           or name of the workspace. ws_id wsid - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace. AND One,
+           and only one, of the numerical id or name of the object. obj_id
+           objid- the numerical ID of the object. obj_name name - name of the
+           object. OPTIONALLY obj_ver ver - the version of the object. OR an
+           object reference string: obj_ref ref - an object reference
+           string.) -> structure: parameter "workspace" of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "obj_ref_path" of list of type "obj_ref" (A string that uniquely
+           identifies an object in the workspace service. The format is
+           [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "obj_path" of type "ref_chain" (A
-           chain of objects with references to one another. An object
-           reference chain consists of a list of objects where the nth object
-           possesses a reference, either in the object itself or in the
-           object provenance, to the n+1th object.) -> list of type
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_path" of type
+           "ref_chain" (A chain of objects with references to one another. An
+           object reference chain consists of a list of objects where the nth
+           object possesses a reference, either in the object itself or in
+           the object provenance, to the n+1th object.) -> list of type
            "ObjectIdentity" (An object identifier. Select an object by
            either: One, and only one, of the numerical id or name of the
-           workspace, where the name can also be a KBase ID including the
-           numerical id, e.g. kb|ws.35. ws_id wsid - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. AND One, and only
-           one, of the numerical id or name of the object. obj_id objid- the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
            numerical ID of the object. obj_name name - name of the object.
            OPTIONALLY obj_ver ver - the version of the object. OR an object
            reference string: obj_ref ref - an object reference string.) ->
@@ -3414,50 +3490,43 @@ class Workspace(object):
            unique, permanent numerical ID of an object.), parameter "ver" of
            type "obj_ver" (An object version. The version of the object,
            starting at 1.), parameter "ref" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "obj_ref_path" of list of type
-           "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "included" of list of type
-           "object_path" (A path into an object. Identify a sub portion of an
-           object by providing the path, delimited by a slash (/), to that
-           portion of the object. Thus the path may not have slashes in the
-           structure or mapping keys. Examples: /foo/bar/3 - specifies the
-           bar key of the foo mapping and the 3rd entry of the array if bar
-           maps to an array or the value mapped to the string "3" if bar maps
-           to a map. /foo/bar/[*]/baz - specifies the baz field of all the
-           objects in the list mapped by the bar key in the map foo.
-           /foo/asterisk/baz - specifies the baz field of all the objects in
-           the values of the foo mapping. Swap 'asterisk' for * in the path.
-           In case you need to use '/' or '~' in path items use JSON Pointer
-           notation defined here: http://tools.ietf.org/html/rfc6901),
-           parameter "strict_maps" of type "boolean" (A boolean. 0 = false,
-           other = true.), parameter "strict_arrays" of type "boolean" (A
-           boolean. 0 = false, other = true.), parameter "includeMetadata" of
-           type "boolean" (A boolean. 0 = false, other = true.), parameter
-           "ignoreErrors" of type "boolean" (A boolean. 0 = false, other =
-           true.)
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_ref_path" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. The format is [ws_name or id]/[obj_name or
+           id]/[obj_ver]. For example, MyFirstWorkspace/MyFirstObject/3 would
+           identify the third version of an object called MyFirstObject in
+           the workspace called MyFirstWorkspace. 42/Panic/1 would identify
+           the first version of the object name Panic in workspace with id
+           42. Towel/1/6 would identify the 6th version of the object with id
+           1 in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "find_reference_path" of type "boolean" (A boolean. 0 = false,
+           other = true.), parameter "included" of list of type "object_path"
+           (A path into an object. Identify a sub portion of an object by
+           providing the path, delimited by a slash (/), to that portion of
+           the object. Thus the path may not have slashes in the structure or
+           mapping keys. Examples: /foo/bar/3 - specifies the bar key of the
+           foo mapping and the 3rd entry of the array if bar maps to an array
+           or the value mapped to the string "3" if bar maps to a map.
+           /foo/bar/[*]/baz - specifies the baz field of all the objects in
+           the list mapped by the bar key in the map foo. /foo/asterisk/baz -
+           specifies the baz field of all the objects in the values of the
+           foo mapping. Swap 'asterisk' for * in the path. In case you need
+           to use '/' or '~' in path items use JSON Pointer notation defined
+           here: http://tools.ietf.org/html/rfc6901), parameter "strict_maps"
+           of type "boolean" (A boolean. 0 = false, other = true.), parameter
+           "strict_arrays" of type "boolean" (A boolean. 0 = false, other =
+           true.), parameter "includeMetadata" of type "boolean" (A boolean.
+           0 = false, other = true.), parameter "ignoreErrors" of type
+           "boolean" (A boolean. 0 = false, other = true.)
         :returns: instance of list of type "object_info" (Information about
            an object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -3507,6 +3576,268 @@ class Workspace(object):
             'Workspace.get_object_info_new',
             [params], self._service_ver, context)
 
+    def get_object_info3(self, params, context=None):
+        """
+        :param params: instance of type "GetObjectInfo3Params" (Input
+           parameters for the "get_object_info3" function. Required
+           arguments: list<ObjectSpecification> objects - the objects for
+           which the information should be fetched. Subsetting related
+           parameters are ignored. Optional arguments: boolean
+           includeMetadata - include the object metadata in the returned
+           information. Default false. boolean ignoreErrors - Don't throw an
+           exception if an object cannot be accessed; return null for that
+           object's information and path instead. Default false.) ->
+           structure: parameter "objects" of list of type
+           "ObjectSpecification" (An Object Specification (OS). Inherits from
+           ObjectIdentity (OI). Specifies which object, and which parts of
+           that object, to retrieve from the Workspace Service. The fields
+           wsid, workspace, objid, name, and ver are identical to the OI
+           fields. The ref field's behavior is extended from OI. It maintains
+           its previous behavior, but now also can act as a reference string.
+           See reference following below for more information. REFERENCE
+           FOLLOWING: Reference following guarantees that a user that has
+           access to an object can always see a) objects that are referenced
+           inside the object and b) objects that are referenced in the
+           object's provenance. This ensures that the user has visibility
+           into the entire provenance of the object and the object's object
+           dependencies (e.g. references). The user must have at least read
+           access to the object specified in this SO, but need not have
+           access to any further objects in the reference chain, and those
+           objects may be deleted. Optional reference following fields: Note
+           that only one of the following fields may be specified. ref_chain
+           obj_path - a path to the desired object from the object specified
+           in this OS. In other words, the object specified in this OS is
+           assumed to be accessible to the user, and the objects in the
+           object path represent a chain of references to the desired object
+           at the end of the object path. If the references are all valid,
+           the desired object will be returned. - OR - list<obj_ref>
+           obj_ref_path - shorthand for the obj_path. - OR - ref_chain
+           to_obj_path - identical to obj_path, except that the path is TO
+           the object specified in this OS, rather than from the object. In
+           other words the object specified by wsid/objid/ref etc. is the end
+           of the path, and to_obj_path is the rest of the path. The user
+           must have access to the first object in the to_obj_path. - OR -
+           list<obj_ref> to_obj_ref_path - shorthand for the to_obj_path. -
+           OR - ref_string ref - A string representing a reference path from
+           one object to another. Unlike the previous reference following
+           options, the ref_string represents the ENTIRE path from the source
+           object to the target object. As with the OI object, the ref field
+           may contain a single reference. - OR - boolean find_refence_path -
+           This is the last, slowest, and most expensive resort for getting a
+           referenced object - do not use this method unless the path to the
+           object is unavailable by any other means. Setting the
+           find_refence_path parameter to true means that the workspace
+           service will search through the object reference graph from the
+           object specified in this OS to find an object that 1) the user can
+           access, and 2) has an unbroken reference path to the target
+           object. If the search succeeds, the object will be returned as
+           normal. Note that the search will automatically fail after a
+           certain (but much larger than necessary for the vast majority of
+           cases) number of objects are traversed. OBJECT SUBSETS: When
+           selecting a subset of an array in an object, the returned array is
+           compressed to the size of the subset, but the ordering of the
+           array is maintained. For example, if the array stored at the
+           'feature' key of a Genome object has 4000 entries, and the object
+           paths provided are: /feature/7 /feature/3015 /feature/700 The
+           returned feature array will be of length three and the entries
+           will consist, in order, of the 7th, 700th, and 3015th entries of
+           the original array. Optional object subset fields:
+           list<object_path> included - the portions of the object to include
+           in the object subset. boolean strict_maps - if true, throw an
+           exception if the subset specification traverses a non-existent map
+           key (default false) boolean strict_arrays - if true, throw an
+           exception if the subset specification exceeds the size of an array
+           (default true)) -> structure: parameter "workspace" of type
+           "ws_name" (A string used as a name for a workspace. Any string
+           consisting of alphanumeric characters and "_", ".", or "-" that is
+           not an integer is acceptable. The name may optionally be prefixed
+           with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "obj_path" of type "ref_chain" (A chain of objects with
+           references to one another. An object reference chain consists of a
+           list of objects where the nth object possesses a reference, either
+           in the object itself or in the object provenance, to the n+1th
+           object.) -> list of type "ObjectIdentity" (An object identifier.
+           Select an object by either: One, and only one, of the numerical id
+           or name of the workspace. ws_id wsid - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace. AND One,
+           and only one, of the numerical id or name of the object. obj_id
+           objid- the numerical ID of the object. obj_name name - name of the
+           object. OPTIONALLY obj_ver ver - the version of the object. OR an
+           object reference string: obj_ref ref - an object reference
+           string.) -> structure: parameter "workspace" of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "obj_ref_path" of list of type "obj_ref" (A string that uniquely
+           identifies an object in the workspace service. The format is
+           [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_path" of type
+           "ref_chain" (A chain of objects with references to one another. An
+           object reference chain consists of a list of objects where the nth
+           object possesses a reference, either in the object itself or in
+           the object provenance, to the n+1th object.) -> list of type
+           "ObjectIdentity" (An object identifier. Select an object by
+           either: One, and only one, of the numerical id or name of the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
+           numerical ID of the object. obj_name name - name of the object.
+           OPTIONALLY obj_ver ver - the version of the object. OR an object
+           reference string: obj_ref ref - an object reference string.) ->
+           structure: parameter "workspace" of type "ws_name" (A string used
+           as a name for a workspace. Any string consisting of alphanumeric
+           characters and "_", ".", or "-" that is not an integer is
+           acceptable. The name may optionally be prefixed with the workspace
+           owner's user name and a colon, e.g. kbasetest:my_workspace.),
+           parameter "wsid" of type "ws_id" (The unique, permanent numerical
+           ID of a workspace.), parameter "name" of type "obj_name" (A string
+           used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "objid" of type "obj_id" (The
+           unique, permanent numerical ID of an object.), parameter "ver" of
+           type "obj_ver" (An object version. The version of the object,
+           starting at 1.), parameter "ref" of type "obj_ref" (A string that
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_ref_path" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. The format is [ws_name or id]/[obj_name or
+           id]/[obj_ver]. For example, MyFirstWorkspace/MyFirstObject/3 would
+           identify the third version of an object called MyFirstObject in
+           the workspace called MyFirstWorkspace. 42/Panic/1 would identify
+           the first version of the object name Panic in workspace with id
+           42. Towel/1/6 would identify the 6th version of the object with id
+           1 in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "find_reference_path" of type "boolean" (A boolean. 0 = false,
+           other = true.), parameter "included" of list of type "object_path"
+           (A path into an object. Identify a sub portion of an object by
+           providing the path, delimited by a slash (/), to that portion of
+           the object. Thus the path may not have slashes in the structure or
+           mapping keys. Examples: /foo/bar/3 - specifies the bar key of the
+           foo mapping and the 3rd entry of the array if bar maps to an array
+           or the value mapped to the string "3" if bar maps to a map.
+           /foo/bar/[*]/baz - specifies the baz field of all the objects in
+           the list mapped by the bar key in the map foo. /foo/asterisk/baz -
+           specifies the baz field of all the objects in the values of the
+           foo mapping. Swap 'asterisk' for * in the path. In case you need
+           to use '/' or '~' in path items use JSON Pointer notation defined
+           here: http://tools.ietf.org/html/rfc6901), parameter "strict_maps"
+           of type "boolean" (A boolean. 0 = false, other = true.), parameter
+           "strict_arrays" of type "boolean" (A boolean. 0 = false, other =
+           true.), parameter "includeMetadata" of type "boolean" (A boolean.
+           0 = false, other = true.), parameter "ignoreErrors" of type
+           "boolean" (A boolean. 0 = false, other = true.)
+        :returns: instance of type "GetObjectInfo3Results" (Output from the
+           get_object_info3 function. list<object_info> infos - the
+           object_info data for each object. list<list<obj_ref> paths - the
+           path to the object through the object reference graph for each
+           object. All the references in the path are absolute.) ->
+           structure: parameter "infos" of list of type "object_info"
+           (Information about an object, including user provided metadata.
+           obj_id objid - the numerical id of the object. obj_name name - the
+           name of the object. type_string type - the type of the object.
+           timestamp save_date - the save date of the object. obj_ver ver -
+           the version of the object. username saved_by - the user that saved
+           or copied the object. ws_id wsid - the workspace containing the
+           object. ws_name workspace - the workspace containing the object.
+           string chsum - the md5 checksum of the object. int size - the size
+           of the object in bytes. usermeta meta - arbitrary user-supplied
+           metadata about the object.) -> tuple of size 11: parameter "objid"
+           of type "obj_id" (The unique, permanent numerical ID of an
+           object.), parameter "name" of type "obj_name" (A string used as a
+           name for an object. Any string consisting of alphanumeric
+           characters and the characters |._- that is not an integer is
+           acceptable.), parameter "type" of type "type_string" (A type
+           string. Specifies the type and its version in a single string in
+           the format [module].[typename]-[major].[minor]: module - a string.
+           The module name of the typespec containing the type. typename - a
+           string. The name of the type as assigned by the typedef statement.
+           major - an integer. The major version of the type. A change in the
+           major version implies the type has changed in a non-backwards
+           compatible way. minor - an integer. The minor version of the type.
+           A change in the minor version implies that the type has changed in
+           a way that is backwards compatible with previous type definitions.
+           In many cases, the major and minor versions are optional, and if
+           not provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String, parameter "paths" of
+           list of list of type "obj_ref" (A string that uniquely identifies
+           an object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.)
+        """
+        return self._client.call_method(
+            'Workspace.get_object_info3',
+            [params], self._service_ver, context)
+
     def rename_workspace(self, params, context=None):
         """
         Rename a workspace.
@@ -3516,10 +3847,8 @@ class Workspace(object):
            ws_name new_name - the new name for the workspace.) -> structure:
            parameter "wsi" of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -3536,26 +3865,28 @@ class Workspace(object):
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -3582,11 +3913,9 @@ class Workspace(object):
            new name for the object.) -> structure: parameter "obj" of type
            "ObjectIdentity" (An object identifier. Select an object by
            either: One, and only one, of the numerical id or name of the
-           workspace, where the name can also be a KBase ID including the
-           numerical id, e.g. kb|ws.35. ws_id wsid - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. AND One, and only
-           one, of the numerical id or name of the object. obj_id objid- the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
            numerical ID of the object. obj_name name - name of the object.
            OPTIONALLY obj_ver ver - the version of the object. OR an object
            reference string: obj_ref ref - an object reference string.) ->
@@ -3603,20 +3932,16 @@ class Workspace(object):
            unique, permanent numerical ID of an object.), parameter "ver" of
            type "obj_ver" (An object version. The version of the object,
            starting at 1.), parameter "ref" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "new_name" of type "obj_name" (A
-           string used as a name for an object. Any string consisting of
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "new_name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
            alphanumeric characters and the characters |._- that is not an
            integer is acceptable.)
         :returns: instance of type "object_info" (Information about an
@@ -3681,46 +4006,9 @@ class Workspace(object):
            object to copy. ObjectIdentity to - where to copy the object.) ->
            structure: parameter "from" of type "ObjectIdentity" (An object
            identifier. Select an object by either: One, and only one, of the
-           numerical id or name of the workspace, where the name can also be
-           a KBase ID including the numerical id, e.g. kb|ws.35. ws_id wsid -
-           the numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78. AND
-           One, and only one, of the numerical id or name of the object.
-           obj_id objid- the numerical ID of the object. obj_name name - name
-           of the object. OPTIONALLY obj_ver ver - the version of the object.
-           OR an object reference string: obj_ref ref - an object reference
-           string.) -> structure: parameter "workspace" of type "ws_name" (A
-           string used as a name for a workspace. Any string consisting of
-           alphanumeric characters and "_", ".", or "-" that is not an
-           integer is acceptable. The name may optionally be prefixed with
-           the workspace owner's user name and a colon, e.g.
-           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
-           unique, permanent numerical ID of a workspace.), parameter "name"
-           of type "obj_name" (A string used as a name for an object. Any
-           string consisting of alphanumeric characters and the characters
-           |._- that is not an integer is acceptable.), parameter "objid" of
-           type "obj_id" (The unique, permanent numerical ID of an object.),
-           parameter "ver" of type "obj_ver" (An object version. The version
-           of the object, starting at 1.), parameter "ref" of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
-           third version of an object called MyFirstObject in the workspace
-           called MyFirstWorkspace. 42/Panic/1 would identify the first
-           version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "to" of type "ObjectIdentity" (An
-           object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           numerical id or name of the workspace. ws_id wsid - the numerical
+           ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -3738,18 +4026,44 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter "to" of type
+           "ObjectIdentity" (An object identifier. Select an object by
+           either: One, and only one, of the numerical id or name of the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
+           numerical ID of the object. obj_name name - name of the object.
+           OPTIONALLY obj_ver ver - the version of the object. OR an object
+           reference string: obj_ref ref - an object reference string.) ->
+           structure: parameter "workspace" of type "ws_name" (A string used
+           as a name for a workspace. Any string consisting of alphanumeric
+           characters and "_", ".", or "-" that is not an integer is
+           acceptable. The name may optionally be prefixed with the workspace
+           owner's user name and a colon, e.g. kbasetest:my_workspace.),
+           parameter "wsid" of type "ws_id" (The unique, permanent numerical
+           ID of a workspace.), parameter "name" of type "obj_name" (A string
+           used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "objid" of type "obj_id" (The
+           unique, permanent numerical ID of an object.), parameter "ver" of
+           type "obj_ver" (An object version. The version of the object,
+           starting at 1.), parameter "ref" of type "obj_ref" (A string that
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.)
         :returns: instance of type "object_info" (Information about an
            object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -3806,19 +4120,17 @@ class Workspace(object):
                 specified in the ObjectIdentity.
         :param object: instance of type "ObjectIdentity" (An object
            identifier. Select an object by either: One, and only one, of the
-           numerical id or name of the workspace, where the name can also be
-           a KBase ID including the numerical id, e.g. kb|ws.35. ws_id wsid -
-           the numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78. AND
-           One, and only one, of the numerical id or name of the object.
-           obj_id objid- the numerical ID of the object. obj_name name - name
-           of the object. OPTIONALLY obj_ver ver - the version of the object.
-           OR an object reference string: obj_ref ref - an object reference
-           string.) -> structure: parameter "workspace" of type "ws_name" (A
-           string used as a name for a workspace. Any string consisting of
-           alphanumeric characters and "_", ".", or "-" that is not an
-           integer is acceptable. The name may optionally be prefixed with
-           the workspace owner's user name and a colon, e.g.
+           numerical id or name of the workspace. ws_id wsid - the numerical
+           ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
+           the object. obj_id objid- the numerical ID of the object. obj_name
+           name - name of the object. OPTIONALLY obj_ver ver - the version of
+           the object. OR an object reference string: obj_ref ref - an object
+           reference string.) -> structure: parameter "workspace" of type
+           "ws_name" (A string used as a name for a workspace. Any string
+           consisting of alphanumeric characters and "_", ".", or "-" that is
+           not an integer is acceptable. The name may optionally be prefixed
+           with the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
            unique, permanent numerical ID of a workspace.), parameter "name"
            of type "obj_name" (A string used as a name for an object. Any
@@ -3828,18 +4140,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of type "object_info" (Information about an
            object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -3903,10 +4211,8 @@ class Workspace(object):
            hidden objects in the results. Default false.) -> structure:
            parameter "workspaces" of list of type "WorkspaceIdentity" (A
            workspace identifier. Select a workspace by one, and only one, of
-           the numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           the numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -3935,11 +4241,9 @@ class Workspace(object):
         appear in the list_objects method.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -3957,18 +4261,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         """
         return self._client.call_method(
             'Workspace.hide_objects',
@@ -3980,11 +4280,9 @@ class Workspace(object):
         of the version specified in the ObjectIdentity.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -4002,18 +4300,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         """
         return self._client.call_method(
             'Workspace.unhide_objects',
@@ -4025,11 +4319,9 @@ class Workspace(object):
         the version specified in the ObjectIdentity.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -4047,18 +4339,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         """
         return self._client.call_method(
             'Workspace.delete_objects',
@@ -4071,11 +4359,9 @@ class Workspace(object):
         deleted, no error is thrown.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -4093,18 +4379,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         """
         return self._client.call_method(
             'Workspace.undelete_objects',
@@ -4115,10 +4397,8 @@ class Workspace(object):
         Delete a workspace. All objects contained in the workspace are deleted.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -4138,10 +4418,8 @@ class Workspace(object):
         deleted.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -83,6 +83,58 @@ function NarrativeService(url, auth, auth_cb, timeout, async_job_check_time_ms, 
         return json_call_ajax(_url, "NarrativeService.list_available_types",
             [params], 1, _callback, _errorCallback);
     };
+ 
+     this.list_narratorials = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "NarrativeService.list_narratorials",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.list_narratives = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "NarrativeService.list_narratives",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.set_narratorial = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "NarrativeService.set_narratorial",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.remove_narratorial = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "NarrativeService.remove_narratorial",
+            [params], 1, _callback, _errorCallback);
+    };
   
     this.status = function (_callback, _errorCallback) {
         if (_callback && typeof _callback !== 'function')

--- a/lib/src/us/kbase/common/service/Tuple9.java
+++ b/lib/src/us/kbase/common/service/Tuple9.java
@@ -1,0 +1,151 @@
+package us.kbase.common.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class Tuple9 <T1, T2, T3, T4, T5, T6, T7, T8, T9> {
+    private T1 e1;
+    private T2 e2;
+    private T3 e3;
+    private T4 e4;
+    private T5 e5;
+    private T6 e6;
+    private T7 e7;
+    private T8 e8;
+    private T9 e9;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    public T1 getE1() {
+        return e1;
+    }
+
+    public void setE1(T1 e1) {
+        this.e1 = e1;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE1(T1 e1) {
+        this.e1 = e1;
+        return this;
+    }
+
+    public T2 getE2() {
+        return e2;
+    }
+
+    public void setE2(T2 e2) {
+        this.e2 = e2;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE2(T2 e2) {
+        this.e2 = e2;
+        return this;
+    }
+
+    public T3 getE3() {
+        return e3;
+    }
+
+    public void setE3(T3 e3) {
+        this.e3 = e3;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE3(T3 e3) {
+        this.e3 = e3;
+        return this;
+    }
+
+    public T4 getE4() {
+        return e4;
+    }
+
+    public void setE4(T4 e4) {
+        this.e4 = e4;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE4(T4 e4) {
+        this.e4 = e4;
+        return this;
+    }
+
+    public T5 getE5() {
+        return e5;
+    }
+
+    public void setE5(T5 e5) {
+        this.e5 = e5;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE5(T5 e5) {
+        this.e5 = e5;
+        return this;
+    }
+
+    public T6 getE6() {
+        return e6;
+    }
+
+    public void setE6(T6 e6) {
+        this.e6 = e6;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE6(T6 e6) {
+        this.e6 = e6;
+        return this;
+    }
+
+    public T7 getE7() {
+        return e7;
+    }
+
+    public void setE7(T7 e7) {
+        this.e7 = e7;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE7(T7 e7) {
+        this.e7 = e7;
+        return this;
+    }
+
+    public T8 getE8() {
+        return e8;
+    }
+
+    public void setE8(T8 e8) {
+        this.e8 = e8;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE8(T8 e8) {
+        this.e8 = e8;
+        return this;
+    }
+
+    public T9 getE9() {
+        return e9;
+    }
+
+    public void setE9(T9 e9) {
+        this.e9 = e9;
+    }
+
+    public Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> withE9(T9 e9) {
+        this.e9 = e9;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Tuple9 [e1=" + e1 + ", e2=" + e2 + ", e3=" + e3 + ", e4=" + e4 + ", e5=" + e5 + ", e6=" + e6 + ", e7=" + e7 + ", e8=" + e8 + ", e9=" + e9 + "]";
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/lib/src/us/kbase/narrativeservice/ListNarrativeParams.java
+++ b/lib/src/us/kbase/narrativeservice/ListNarrativeParams.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <pre>
  * List narratives
  * type parameter indicates which narratives to return.
- * Supported options are for now 'mine' or 'public'  TODO: 'shared'
+ * Supported options are for now 'mine', 'public', or 'shared'
  * </pre>
  * 
  */

--- a/lib/src/us/kbase/narrativeservice/ListNarrativeParams.java
+++ b/lib/src/us/kbase/narrativeservice/ListNarrativeParams.java
@@ -1,0 +1,64 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ListNarrativeParams</p>
+ * <pre>
+ * List narratives
+ * type parameter indicates which narratives to return.
+ * Supported options are for now 'mine' or 'public'  TODO: 'shared'
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "type"
+})
+public class ListNarrativeParams {
+
+    @JsonProperty("type")
+    private String type;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public ListNarrativeParams withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((("ListNarrativeParams"+" [type=")+ type)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/ListNarratorialParams.java
+++ b/lib/src/us/kbase/narrativeservice/ListNarratorialParams.java
@@ -1,0 +1,44 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ListNarratorialParams</p>
+ * <pre>
+ * Listing Narratives / Naratorials (plus Narratorial Management)
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+
+})
+public class ListNarratorialParams {
+
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((("ListNarratorialParams"+" [additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/Narrative.java
+++ b/lib/src/us/kbase/narrativeservice/Narrative.java
@@ -1,0 +1,80 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple11;
+import us.kbase.common.service.Tuple9;
+
+
+/**
+ * <p>Original spec-file type: Narrative</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "ws",
+    "nar"
+})
+public class Narrative {
+
+    @JsonProperty("ws")
+    private Tuple9 <Long, String, String, String, Long, String, String, String, Map<String, String>> ws;
+    @JsonProperty("nar")
+    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> nar;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("ws")
+    public Tuple9 <Long, String, String, String, Long, String, String, String, Map<String, String>> getWs() {
+        return ws;
+    }
+
+    @JsonProperty("ws")
+    public void setWs(Tuple9 <Long, String, String, String, Long, String, String, String, Map<String, String>> ws) {
+        this.ws = ws;
+    }
+
+    public Narrative withWs(Tuple9 <Long, String, String, String, Long, String, String, String, Map<String, String>> ws) {
+        this.ws = ws;
+        return this;
+    }
+
+    @JsonProperty("nar")
+    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getNar() {
+        return nar;
+    }
+
+    @JsonProperty("nar")
+    public void setNar(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> nar) {
+        this.nar = nar;
+    }
+
+    public Narrative withNar(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> nar) {
+        this.nar = nar;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((("Narrative"+" [ws=")+ ws)+", nar=")+ nar)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/NarrativeList.java
+++ b/lib/src/us/kbase/narrativeservice/NarrativeList.java
@@ -1,0 +1,61 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: NarrativeList</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "narratives"
+})
+public class NarrativeList {
+
+    @JsonProperty("narratives")
+    private List<Narrative> narratives;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("narratives")
+    public List<Narrative> getNarratives() {
+        return narratives;
+    }
+
+    @JsonProperty("narratives")
+    public void setNarratives(List<Narrative> narratives) {
+        this.narratives = narratives;
+    }
+
+    public NarrativeList withNarratives(List<Narrative> narratives) {
+        this.narratives = narratives;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((("NarrativeList"+" [narratives=")+ narratives)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/NarrativeServiceClient.java
+++ b/lib/src/us/kbase/narrativeservice/NarrativeServiceClient.java
@@ -247,6 +247,79 @@ public class NarrativeServiceClient {
         return res.get(0);
     }
 
+    /**
+     * <p>Original spec-file function name: list_narratorials</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.narrativeservice.ListNarratorialParams ListNarratorialParams}
+     * @return   instance of type {@link us.kbase.narrativeservice.NarratorialList NarratorialList}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public NarratorialList listNarratorials(ListNarratorialParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<NarratorialList>> retType = new TypeReference<List<NarratorialList>>() {};
+        List<NarratorialList> res = caller.jsonrpcCall("NarrativeService.list_narratorials", args, retType, true, false, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: list_narratives</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.narrativeservice.ListNarrativeParams ListNarrativeParams}
+     * @return   instance of type {@link us.kbase.narrativeservice.NarrativeList NarrativeList}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public NarrativeList listNarratives(ListNarrativeParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<NarrativeList>> retType = new TypeReference<List<NarrativeList>>() {};
+        List<NarrativeList> res = caller.jsonrpcCall("NarrativeService.list_narratives", args, retType, true, false, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: set_narratorial</p>
+     * <pre>
+     * Allows a user to create a Narratorial given a WS they own. Right now
+     * anyone can do this, but we may restrict in the future to users that
+     * have a particular role.  Run simply as:
+     *     ns.set_narratorial({'ws':'MyWsName'}) or,
+     *     ns.set_narratorial({'ws':'4231'})
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.narrativeservice.SetNarratorialParams SetNarratorialParams}
+     * @return   instance of type {@link us.kbase.narrativeservice.SetNarratorialResult SetNarratorialResult}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public SetNarratorialResult setNarratorial(SetNarratorialParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<SetNarratorialResult>> retType = new TypeReference<List<SetNarratorialResult>>() {};
+        List<SetNarratorialResult> res = caller.jsonrpcCall("NarrativeService.set_narratorial", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: remove_narratorial</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.narrativeservice.RemoveNarratorialParams RemoveNarratorialParams}
+     * @return   instance of type {@link us.kbase.narrativeservice.RemoveNarratorialResult RemoveNarratorialResult}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public RemoveNarratorialResult removeNarratorial(RemoveNarratorialParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<RemoveNarratorialResult>> retType = new TypeReference<List<RemoveNarratorialResult>>() {};
+        List<RemoveNarratorialResult> res = caller.jsonrpcCall("NarrativeService.remove_narratorial", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
     public Map<String, Object> status(RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         TypeReference<List<Map<String, Object>>> retType = new TypeReference<List<Map<String, Object>>>() {};

--- a/lib/src/us/kbase/narrativeservice/Narratorial.java
+++ b/lib/src/us/kbase/narrativeservice/Narratorial.java
@@ -1,0 +1,82 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple11;
+import us.kbase.common.service.Tuple9;
+
+
+/**
+ * <p>Original spec-file type: Narratorial</p>
+ * <pre>
+ * info for a narratorial
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "ws",
+    "nar"
+})
+public class Narratorial {
+
+    @JsonProperty("ws")
+    private Tuple9 <Long, String, String, String, Long, String, String, String, Map<String, String>> ws;
+    @JsonProperty("nar")
+    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> nar;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("ws")
+    public Tuple9 <Long, String, String, String, Long, String, String, String, Map<String, String>> getWs() {
+        return ws;
+    }
+
+    @JsonProperty("ws")
+    public void setWs(Tuple9 <Long, String, String, String, Long, String, String, String, Map<String, String>> ws) {
+        this.ws = ws;
+    }
+
+    public Narratorial withWs(Tuple9 <Long, String, String, String, Long, String, String, String, Map<String, String>> ws) {
+        this.ws = ws;
+        return this;
+    }
+
+    @JsonProperty("nar")
+    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getNar() {
+        return nar;
+    }
+
+    @JsonProperty("nar")
+    public void setNar(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> nar) {
+        this.nar = nar;
+    }
+
+    public Narratorial withNar(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> nar) {
+        this.nar = nar;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((("Narratorial"+" [ws=")+ ws)+", nar=")+ nar)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/NarratorialList.java
+++ b/lib/src/us/kbase/narrativeservice/NarratorialList.java
@@ -1,0 +1,61 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: NarratorialList</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "narratorials"
+})
+public class NarratorialList {
+
+    @JsonProperty("narratorials")
+    private List<Narratorial> narratorials;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("narratorials")
+    public List<Narratorial> getNarratorials() {
+        return narratorials;
+    }
+
+    @JsonProperty("narratorials")
+    public void setNarratorials(List<Narratorial> narratorials) {
+        this.narratorials = narratorials;
+    }
+
+    public NarratorialList withNarratorials(List<Narratorial> narratorials) {
+        this.narratorials = narratorials;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((("NarratorialList"+" [narratorials=")+ narratorials)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/RemoveNarratorialParams.java
+++ b/lib/src/us/kbase/narrativeservice/RemoveNarratorialParams.java
@@ -1,0 +1,60 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: RemoveNarratorialParams</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "ws"
+})
+public class RemoveNarratorialParams {
+
+    @JsonProperty("ws")
+    private String ws;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("ws")
+    public String getWs() {
+        return ws;
+    }
+
+    @JsonProperty("ws")
+    public void setWs(String ws) {
+        this.ws = ws;
+    }
+
+    public RemoveNarratorialParams withWs(String ws) {
+        this.ws = ws;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((("RemoveNarratorialParams"+" [ws=")+ ws)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/RemoveNarratorialResult.java
+++ b/lib/src/us/kbase/narrativeservice/RemoveNarratorialResult.java
@@ -1,0 +1,42 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: RemoveNarratorialResult</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+
+})
+public class RemoveNarratorialResult {
+
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((("RemoveNarratorialResult"+" [additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/SetNarratorialParams.java
+++ b/lib/src/us/kbase/narrativeservice/SetNarratorialParams.java
@@ -1,0 +1,81 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: SetNarratorialParams</p>
+ * <pre>
+ * ws field is a string, but properly interpreted whether it is a workspace
+ * name or ID
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "ws",
+    "description"
+})
+public class SetNarratorialParams {
+
+    @JsonProperty("ws")
+    private String ws;
+    @JsonProperty("description")
+    private String description;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("ws")
+    public String getWs() {
+        return ws;
+    }
+
+    @JsonProperty("ws")
+    public void setWs(String ws) {
+        this.ws = ws;
+    }
+
+    public SetNarratorialParams withWs(String ws) {
+        this.ws = ws;
+        return this;
+    }
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public SetNarratorialParams withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("SetNarratorialParams"+" [ws=")+ ws)+", description=")+ description)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/narrativeservice/SetNarratorialResult.java
+++ b/lib/src/us/kbase/narrativeservice/SetNarratorialResult.java
@@ -1,0 +1,42 @@
+
+package us.kbase.narrativeservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: SetNarratorialResult</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+
+})
+public class SetNarratorialResult {
+
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((("SetNarratorialResult"+" [additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/test/NarrativeListUtils_test.py
+++ b/test/NarrativeListUtils_test.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+import unittest
+import os  # noqa: F401
+import json  # noqa: F401
+import time
+import requests
+import StringIO
+
+from os import environ
+from NarrativeService.NarrativeManager import NarrativeManager
+try:
+    from ConfigParser import ConfigParser  # py2
+except:
+    from configparser import ConfigParser  # py3
+
+from pprint import pprint  # noqa: F401
+
+from Workspace.WorkspaceClient import Workspace
+from NarrativeService.NarrativeServiceImpl import NarrativeService
+from NarrativeService.NarrativeServiceServer import MethodContext
+from DataPaletteService.authclient import KBaseAuth as _KBaseAuth
+
+from NarrativeService.NarrativeListUtils import NarrativeInfoCache, NarratorialUtils, NarrativeListUtils
+
+
+class NarrativeListUtilsTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        token = environ.get('KB_AUTH_TOKEN', None)
+        config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
+        cls.cfg = {}
+        config = ConfigParser()
+        config.read(config_file)
+        for nameval in config.items('NarrativeService'):
+            cls.cfg[nameval[0]] = nameval[1]
+        authServiceUrl = cls.cfg.get('auth-service-url',
+                "https://kbase.us/services/authorization/Sessions/Login")
+        auth_client = _KBaseAuth(authServiceUrl)
+        user_id = auth_client.get_user(token)
+        # WARNING: don't call any logging methods on the context object,
+        # it'll result in a NoneType error
+        cls.ctx = MethodContext(None)
+        cls.ctx.update({'token': token,
+                        'user_id': user_id,
+                        'provenance': [
+                            {'service': 'NarrativeService',
+                             'method': 'please_never_use_it_in_production',
+                             'method_params': []
+                             }],
+                        'authenticated': 1})
+        cls.wsURL = cls.cfg['workspace-url']
+        cls.wsClient = Workspace(cls.wsURL, token=token)
+        cls.serviceImpl = NarrativeService(cls.cfg)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def getWsClient(self):
+        return self.__class__.wsClients[0]
+
+    def getImpl(self):
+        return self.__class__.serviceImpl
+
+    def getContext(self):
+        return self.__class__.ctx
+
+    def test_narrative_info_cache(self):
+
+        ws_list = self.wsClient.list_workspace_info({})
+
+        ws_lookup_table = {}
+        for ws_info in ws_list:
+            if 'narrative' in ws_info[8]:
+                ws_lookup_table[ws_info[0]] = ws_info
+
+        nic = NarrativeInfoCache(5000)
+        self.assertEquals(nic.check_cache_size(), 0)
+        t1 = time.time()
+        nic.get_info_list(ws_lookup_table, self.wsClient)
+        t2 = time.time()
+        t3 = time.time()
+        nic.get_info_list(ws_lookup_table, self.wsClient)
+        t4 = time.time()
+        self.assertTrue(nic.check_cache_size() > 0)
+        pprint(nic.clear_cache())
+        self.assertEquals(nic.check_cache_size(), 0)
+
+        wsName = "test_NarrativeService_CacheTest_" + str(int(time.time() * 1000))
+        ws_info = self.wsClient.create_workspace({'workspace': wsName})
+        ws_lookup_table[ws_info[0]] = ws_info
+        t5 = time.time()
+        nic.get_info_list(ws_lookup_table, self.wsClient)
+        t6 = time.time()
+
+        # cached access should always be significantly faster, if not we have a problem
+        print('Empty cache call took  %0.3f ms' % ((t2 - t1) * 1000.0))
+        print('Fully cached call took %0.3f ms' % ((t4 - t3) * 1000.0))
+        print('One cache miss call took  %0.3f ms' % ((t6 - t5) * 1000.0))
+        self.assertTrue((t2 - t1) > (t4 - t3))
+
+
+    def test_narratorial_utils_and_listing(self):
+
+        suffix = int(time.time() * 1000)
+        wsName = "test_NarrativeService_Narratorial_" + str(suffix)
+        ws_info = self.wsClient.create_workspace({'workspace': wsName})
+        wsid = ws_info[0]
+
+        nu = NarratorialUtils()
+        nu.set_narratorial(wsid, 'some narratorial', self.wsClient)
+        nar_info = self.wsClient.save_objects({'workspace': wsName,
+                                               'objects': [{'type': 'KBaseNarrative.Narrative',
+                                                            'data': {'nbformat_minor': 0,
+                                                                     'cells': [],
+                                                                     'metadata': {'description': '',
+                                                                                  'data_dependencies': []},
+                                                                     'nbformat': 4},
+                                                            'name': 'narrrrr',
+                                                            'provenance': []}]})[0]
+        self.wsClient.alter_workspace_metadata({'wsi': {'id': wsid}, 'new': {'narrative': nar_info[0]}})
+
+        nlu = NarrativeListUtils(5000)
+        narratorial_list = nlu.list_narratorials(self.wsClient)
+        self.assertTrue(len(narratorial_list) > 0)
+        found = False
+        for nt in narratorial_list:
+            self.assertIn('ws', nt)
+            self.assertIn('nar', nt)
+            self.assertIn('narratorial', nt['ws'][8])
+            self.assertIn('narratorial_description', nt['ws'][8])
+            self.assertTrue(int(nt['ws'][8]['narrative']), nt['nar'][0])
+            if wsid == nt['ws'][0]:
+                found = True
+                self.assertEquals('some narratorial', nt['ws'][8]['narratorial_description'])
+
+        self.assertTrue(found)
+
+        # remove the narratorial, make sure it doesn't show up anymore
+        nu.remove_narratorial(wsid, self.wsClient)
+
+        narratorial_list = nlu.list_narratorials(self.wsClient)
+        found = False
+        for nt in narratorial_list:
+            self.assertIn('ws', nt)
+            self.assertIn('nar', nt)
+            self.assertTrue(int(nt['ws'][8]['narrative']), nt['nar'][0])
+            if wsid == nt['ws'][0]:
+                found = True
+        self.assertTrue(not found)
+
+        self.wsClient.delete_workspace({'id': wsid})


### PR DESCRIPTION
Combines the calls for listing workspaces and data objects into a single call, with narrative information cached if the ws hasn't been updated.

current coverage:
```
...................
Name                                               Stmts   Miss  Cover
----------------------------------------------------------------------
NarrativeService/DataPaletteTypes.py                  15      0   100%
NarrativeService/DynamicServiceCache.py               32      7    78%
NarrativeService/NarrativeListUtils.py                99      1    99%
NarrativeService/NarrativeManager.py                 335     52    84%
NarrativeService/NarrativeServiceImpl.py             113     15    87%
NarrativeService/NarrativeServiceServer.py           385    275    29%
NarrativeService/ServiceUtils.py                      14      0   100%
NarrativeService/WorkspaceListObjectsIterator.py      59      4    93%
NarrativeService.py                                    0      0   100%
NarrativeService/authclient.py                        58     37    36%
NarrativeService/baseclient.py                       147     78    47%
----------------------------------------------------------------------
TOTAL                                               1257    469    63%
None----------------------------------------------------------------------
```