### PR TITLE
fix (hardcode) base URLs for documentation links

### DIFF
--- a/local_data/welcome-cell-content.md
+++ b/local_data/welcome-cell-content.md
@@ -1,17 +1,17 @@
 ## Welcome to KBase's Narrative Interface!
 
-**What's a Narrative?** Narratives are shareable, reproducible workflows that can include data, analysis steps, results, visualizations and commentary. [Learn more...]({{config.resources.docSite.base.url}}/narrative-guide)
+**What's a Narrative?** Narratives are shareable, reproducible workflows that can include data, analysis steps, results, visualizations and commentary. [Learn more...](http://kbase.us/narrative-guide)
 
 **Take the Tour:** Choose "Narrative Tour" from the "Help" menu above. The tour walks you through the user interface, pointing out various useful aspects of it.
 
-**Get Some Data:** Click the Add Data button in the Data Panel to search KBase data or upload your own. Mouse over a data object to add it to your Narrative. [Learn more...]({{config.resources.docSite.base.url}}/narrative-guide/explore-data)
+**Get Some Data:** Click the Add Data button in the Data Panel to search KBase data or upload your own. Mouse over a data object to add it to your Narrative. [Learn more...](http://kbase.us/narrative-guide/explore-data)
 
-**Analyze It:** Use the Apps panel or the App Catalog to browse available analysis apps. Select an app to add it to your Narrative, fill in the fields, and click the "play" button to launch the app. [Learn more...]({{config.resources.docSite.base.url}}/narrative-guide/browse-apps-and-methods)
+**Analyze It:** Use the Apps panel or the App Catalog to browse available analysis apps. Select an app to add it to your Narrative, fill in the fields, and click the "play" button to launch the app. [Learn more...](http://kbase.us/narrative-guide/browse-apps-and-methods)
 
-**Save and Share Your Narrative:** Be sure to save your Narrative frequently. To let collaborators view your analysis steps and results, click the Share button. Or make your Narrative public and help expand the social web that KBase is building to make systems biology research more open, reproducible and collaborative. [Learn more...]({{config.resources.docSite.base.url}}/narrative-guide/share-narratives/)
+**Save and Share Your Narrative:** Be sure to save your Narrative frequently. To let collaborators view your analysis steps and results, click the Share button. Or make your Narrative public and help expand the social web that KBase is building to make systems biology research more open, reproducible and collaborative. [Learn more...](http://kbase.us/narrative-guide/share-narratives/)
 
-**Find Documentation:** For more information, please see the [Narrative Interface User Guide]({{config.resources.docSite.base.url}}/narrative-guide) or the [tutorials]({{config.resources.docSite.base.url}}/tutorials).
+**Find Documentation:** For more information, please see the [Narrative Interface User Guide](http://kbase.us/narrative-guide) or the [tutorials](http://kbase.us/tutorials).
 
-**Questions? Bug reports?** [Contact us]({{config.resources.docSite.base.url}}/contact-us)!
+**Questions? Bug reports?** [Contact us](http://kbase.us/contact-us)!
 
 > Ready to begin adding to your Narrative? You can keep this Welcome cell or delete it by selecting "Delete cell" from the "..." menu in the top right corner of this cell.


### PR DESCRIPTION
Addresses PTV-261
The links out to documentation pages all looked like https://narrative.kbase.us/narrative/%7B%7Bconfig.resources.docSite.base.url%7D%7D/narrative-guide (should be http://kbase.us/narrative-guide/), and similarly for the other links in the Welcome cell.

In this md, those links were represented as
({{config.resources.docSite.base.url}}/narrative-guide)
i'm not sure how to fix those (i don't know what code is supposed to translate config.resources.docSite.base.url to a proper base url) so @msneddon said it would be ok to hardcode the correct URLs for now (and he will redeploy to prod).