### PR TITLE
KBASE-5376 Add an optional 'title' flag to the create_new_narrative function

### DIFF
--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -52,7 +52,7 @@ module NarrativeService {
         mapping<string, string> meta> object_info;
 
     /* Information about a workspace.
-    
+
         ws_id id - the numerical ID of the workspace.
         ws_name workspace - name of the workspace.
         username owner - name of the user who owns (e.g. created) this workspace.
@@ -66,7 +66,7 @@ module NarrativeService {
         lock_status lockstat - the status of the workspace lock.
         usermeta metadata - arbitrary user-supplied metadata about
             the workspace.
-            
+
     */
     typedef tuple<int id, string workspace, string owner, string moddate,
         int max_objid, string user_permission, string globalread,
@@ -78,7 +78,7 @@ module NarrativeService {
 
     /*
         ref - reference to any DataPalette container pointing to given object,
-        refs - list of references to all DataPalette containers pointing to 
+        refs - list of references to all DataPalette containers pointing to
             given object.
     */
     typedef structure {
@@ -222,6 +222,8 @@ module NarrativeService {
         copydata - packed inport data in format "import(;...)*" (alternative to importData)
         importData - import data in unpacked form (alternative to copydata)
         includeIntroCell - if 1, adds an introductory markdown cell at the top (optional, default 0)
+        title - name of the new narrative (optional, if a string besides 'Untitled', this will
+                mark the narrative as not temporary, so it will appear in the dashboard)
     */
     typedef structure {
         string app;
@@ -232,6 +234,7 @@ module NarrativeService {
         string copydata;
         list<string> importData;
         boolean includeIntroCell;
+        string title;
     } CreateNewNarrativeParams;
 
     typedef structure {
@@ -306,7 +309,7 @@ module NarrativeService {
         returns (NarratorialList) authentication optional;
 
 
-    
+
 
     typedef structure {
         workspace_info ws;

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.7
+    0.0.8
 
 owners:
     [rsutormin, msneddon, wjriehl]

--- a/lib/NarrativeService/NarrativeServiceClient.pm
+++ b/lib/NarrativeService/NarrativeServiceClient.pm
@@ -372,6 +372,7 @@ CreateNewNarrativeParams is a reference to a hash where the following keys are d
 	copydata has a value which is a string
 	importData has a value which is a reference to a list where each element is a string
 	includeIntroCell has a value which is a NarrativeService.boolean
+	title has a value which is a string
 AppParam is a reference to a list containing 3 items:
 	0: (step_pos) an int
 	1: (key) a string
@@ -431,6 +432,7 @@ CreateNewNarrativeParams is a reference to a hash where the following keys are d
 	copydata has a value which is a string
 	importData has a value which is a reference to a list where each element is a string
 	includeIntroCell has a value which is a NarrativeService.boolean
+	title has a value which is a string
 AppParam is a reference to a list containing 3 items:
 	0: (step_pos) an int
 	1: (key) a string
@@ -1520,19 +1522,19 @@ a reference to a list containing 11 items:
 
 Information about a workspace.
 
-    ws_id id - the numerical ID of the workspace.
-    ws_name workspace - name of the workspace.
-    username owner - name of the user who owns (e.g. created) this workspace.
-    timestamp moddate - date when the workspace was last modified.
-    int max_objid - the maximum object ID appearing in this workspace.
-        Since cloning a workspace preserves object IDs, this number may be
-        greater than the number of objects in a newly cloned workspace.
-    permission user_permission - permissions for the authenticated user of
-        this workspace.
-    permission globalread - whether this workspace is globally readable.
-    lock_status lockstat - the status of the workspace lock.
-    usermeta metadata - arbitrary user-supplied metadata about
-        the workspace.
+        ws_id id - the numerical ID of the workspace.
+        ws_name workspace - name of the workspace.
+        username owner - name of the user who owns (e.g. created) this workspace.
+        timestamp moddate - date when the workspace was last modified.
+        int max_objid - the maximum object ID appearing in this workspace.
+            Since cloning a workspace preserves object IDs, this number may be
+            greater than the number of objects in a newly cloned workspace.
+        permission user_permission - permissions for the authenticated user of
+            this workspace.
+        permission globalread - whether this workspace is globally readable.
+        lock_status lockstat - the status of the workspace lock.
+        usermeta metadata - arbitrary user-supplied metadata about
+            the workspace.
 
 
 =item Definition
@@ -1614,7 +1616,7 @@ set_items_info has a value which is a reference to a list where each element is 
 =item Description
 
 ref - reference to any DataPalette container pointing to given object,
-refs - list of references to all DataPalette containers pointing to 
+refs - list of references to all DataPalette containers pointing to
     given object.
 
 
@@ -2044,6 +2046,8 @@ markdown - markdown text for cell of 'markdown' type (optional)
 copydata - packed inport data in format "import(;...)*" (alternative to importData)
 importData - import data in unpacked form (alternative to copydata)
 includeIntroCell - if 1, adds an introductory markdown cell at the top (optional, default 0)
+title - name of the new narrative (optional, if a string besides 'Untitled', this will
+        mark the narrative as not temporary, so it will appear in the dashboard)
 
 
 =item Definition
@@ -2060,6 +2064,7 @@ markdown has a value which is a string
 copydata has a value which is a string
 importData has a value which is a reference to a list where each element is a string
 includeIntroCell has a value which is a NarrativeService.boolean
+title has a value which is a string
 
 </pre>
 
@@ -2076,6 +2081,7 @@ markdown has a value which is a string
 copydata has a value which is a string
 importData has a value which is a reference to a list where each element is a string
 includeIntroCell has a value which is a NarrativeService.boolean
+title has a value which is a string
 
 
 =end text

--- a/lib/NarrativeService/NarrativeServiceClient.py
+++ b/lib/NarrativeService/NarrativeServiceClient.py
@@ -132,14 +132,17 @@ class NarrativeService(object):
            (optional) copydata - packed inport data in format "import(;...)*"
            (alternative to importData) importData - import data in unpacked
            form (alternative to copydata) includeIntroCell - if 1, adds an
-           introductory markdown cell at the top (optional, default 0)) ->
-           structure: parameter "app" of String, parameter "method" of
-           String, parameter "appparam" of String, parameter "appData" of
-           list of type "AppParam" -> tuple of size 3: parameter "step_pos"
-           of Long, parameter "key" of String, parameter "value" of String,
-           parameter "markdown" of String, parameter "copydata" of String,
-           parameter "importData" of list of String, parameter
-           "includeIntroCell" of type "boolean" (@range [0,1])
+           introductory markdown cell at the top (optional, default 0) title
+           - name of the new narrative (optional, if a string besides
+           'Untitled', this will mark the narrative as not temporary, so it
+           will appear in the dashboard)) -> structure: parameter "app" of
+           String, parameter "method" of String, parameter "appparam" of
+           String, parameter "appData" of list of type "AppParam" -> tuple of
+           size 3: parameter "step_pos" of Long, parameter "key" of String,
+           parameter "value" of String, parameter "markdown" of String,
+           parameter "copydata" of String, parameter "importData" of list of
+           String, parameter "includeIntroCell" of type "boolean" (@range
+           [0,1]), parameter "title" of String
         :returns: instance of type "CreateNewNarrativeOutput" -> structure:
            parameter "workspaceInfo" of type "WorkspaceInfo" (Restructured
            workspace info 'wsInfo' tuple: id: wsInfo[0], name: wsInfo[1],

--- a/lib/NarrativeService/NarrativeServiceImpl.py
+++ b/lib/NarrativeService/NarrativeServiceImpl.py
@@ -22,9 +22,9 @@ class NarrativeService:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.0.3"
-    GIT_URL = "git@github.com:kbaseapps/NarrativeService"
-    GIT_COMMIT_HASH = "868fb02d7d38125c905aab8a13e6267f92b73535"
+    VERSION = "0.0.7"
+    GIT_URL = "https://github.com/briehl/NarrativeService"
+    GIT_COMMIT_HASH = "0489b972a84475ee9c89f42263abb5ca0de4c67c"
 
     #BEGIN_CLASS_HEADER
     def _nm(self, ctx):
@@ -178,14 +178,17 @@ class NarrativeService:
            (optional) copydata - packed inport data in format "import(;...)*"
            (alternative to importData) importData - import data in unpacked
            form (alternative to copydata) includeIntroCell - if 1, adds an
-           introductory markdown cell at the top (optional, default 0)) ->
-           structure: parameter "app" of String, parameter "method" of
-           String, parameter "appparam" of String, parameter "appData" of
-           list of type "AppParam" -> tuple of size 3: parameter "step_pos"
-           of Long, parameter "key" of String, parameter "value" of String,
-           parameter "markdown" of String, parameter "copydata" of String,
-           parameter "importData" of list of String, parameter
-           "includeIntroCell" of type "boolean" (@range [0,1])
+           introductory markdown cell at the top (optional, default 0) title
+           - name of the new narrative (optional, if a string besides
+           'Untitled', this will mark the narrative as not temporary, so it
+           will appear in the dashboard)) -> structure: parameter "app" of
+           String, parameter "method" of String, parameter "appparam" of
+           String, parameter "appData" of list of type "AppParam" -> tuple of
+           size 3: parameter "step_pos" of Long, parameter "key" of String,
+           parameter "value" of String, parameter "markdown" of String,
+           parameter "copydata" of String, parameter "importData" of list of
+           String, parameter "includeIntroCell" of type "boolean" (@range
+           [0,1]), parameter "title" of String
         :returns: instance of type "CreateNewNarrativeOutput" -> structure:
            parameter "workspaceInfo" of type "WorkspaceInfo" (Restructured
            workspace info 'wsInfo' tuple: id: wsInfo[0], name: wsInfo[1],
@@ -241,8 +244,11 @@ class NarrativeService:
         copydata = params.get('copydata')
         importData = params.get('importData')
         includeIntroCell = params.get('includeIntroCell', 0)
-        returnVal = self._nm(ctx).create_new_narrative(app, method, appparam, appData, markdown,
-                                                       copydata, importData, includeIntroCell)
+        title = params.get('title', None)
+        returnVal = self._nm(ctx).create_new_narrative(
+            app, method, appparam, appData, markdown, copydata, importData,
+            includeIntroCell, title
+        )
         #END create_new_narrative
 
         # At some point might do deeper type checking...

--- a/lib/src/us/kbase/narrativeservice/CreateNewNarrativeParams.java
+++ b/lib/src/us/kbase/narrativeservice/CreateNewNarrativeParams.java
@@ -25,6 +25,8 @@ import us.kbase.common.service.Tuple3;
  * copydata - packed inport data in format "import(;...)*" (alternative to importData)
  * importData - import data in unpacked form (alternative to copydata)
  * includeIntroCell - if 1, adds an introductory markdown cell at the top (optional, default 0)
+ * title - name of the new narrative (optional, if a string besides 'Untitled', this will
+ *         mark the narrative as not temporary, so it will appear in the dashboard)
  * </pre>
  * 
  */
@@ -38,7 +40,8 @@ import us.kbase.common.service.Tuple3;
     "markdown",
     "copydata",
     "importData",
-    "includeIntroCell"
+    "includeIntroCell",
+    "title"
 })
 public class CreateNewNarrativeParams {
 
@@ -58,6 +61,8 @@ public class CreateNewNarrativeParams {
     private List<String> importData;
     @JsonProperty("includeIntroCell")
     private java.lang.Long includeIntroCell;
+    @JsonProperty("title")
+    private java.lang.String title;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     @JsonProperty("app")
@@ -180,6 +185,21 @@ public class CreateNewNarrativeParams {
         return this;
     }
 
+    @JsonProperty("title")
+    public java.lang.String getTitle() {
+        return title;
+    }
+
+    @JsonProperty("title")
+    public void setTitle(java.lang.String title) {
+        this.title = title;
+    }
+
+    public CreateNewNarrativeParams withTitle(java.lang.String title) {
+        this.title = title;
+        return this;
+    }
+
     @JsonAnyGetter
     public Map<java.lang.String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -192,7 +212,7 @@ public class CreateNewNarrativeParams {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((("CreateNewNarrativeParams"+" [app=")+ app)+", method=")+ method)+", appparam=")+ appparam)+", appData=")+ appData)+", markdown=")+ markdown)+", copydata=")+ copydata)+", importData=")+ importData)+", includeIntroCell=")+ includeIntroCell)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((("CreateNewNarrativeParams"+" [app=")+ app)+", method=")+ method)+", appparam=")+ appparam)+", appData=")+ appData)+", markdown=")+ markdown)+", copydata=")+ copydata)+", importData=")+ importData)+", includeIntroCell=")+ includeIntroCell)+", title=")+ title)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/narrativeservice/DataPaletteInfo.java
+++ b/lib/src/us/kbase/narrativeservice/DataPaletteInfo.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <p>Original spec-file type: DataPaletteInfo</p>
  * <pre>
  * ref - reference to any DataPalette container pointing to given object,
- * refs - list of references to all DataPalette containers pointing to 
+ * refs - list of references to all DataPalette containers pointing to
  *     given object.
  * </pre>
  * 

--- a/lib/src/us/kbase/narrativeservice/ListItem.java
+++ b/lib/src/us/kbase/narrativeservice/ListItem.java
@@ -44,7 +44,7 @@ public class ListItem {
      * <p>Original spec-file type: DataPaletteInfo</p>
      * <pre>
      * ref - reference to any DataPalette container pointing to given object,
-     * refs - list of references to all DataPalette containers pointing to 
+     * refs - list of references to all DataPalette containers pointing to
      *     given object.
      * </pre>
      * 
@@ -97,7 +97,7 @@ public class ListItem {
      * <p>Original spec-file type: DataPaletteInfo</p>
      * <pre>
      * ref - reference to any DataPalette container pointing to given object,
-     * refs - list of references to all DataPalette containers pointing to 
+     * refs - list of references to all DataPalette containers pointing to
      *     given object.
      * </pre>
      * 
@@ -111,7 +111,7 @@ public class ListItem {
      * <p>Original spec-file type: DataPaletteInfo</p>
      * <pre>
      * ref - reference to any DataPalette container pointing to given object,
-     * refs - list of references to all DataPalette containers pointing to 
+     * refs - list of references to all DataPalette containers pointing to
      *     given object.
      * </pre>
      * 

--- a/test/NarrativeService_server_test.py
+++ b/test/NarrativeService_server_test.py
@@ -397,8 +397,7 @@ class NarrativeServiceTest(unittest.TestCase):
             # Cleaning up new created workspace
             ws2.delete_workspace({'id': copy_ws_id})
 
-
-    def test_create_new_narrative(self):
+    def test_create_new_temp_narrative(self):
         import_ref = self.__class__.example_reads_ref
         ws = self.getWsClient()
         ret = self.getImpl().create_new_narrative(self.getContext(),
@@ -406,7 +405,50 @@ class NarrativeServiceTest(unittest.TestCase):
                                                    "appparam": "0,param1,value1;0,param2,value2",
                                                    "copydata": import_ref})[0]
         try:
-            self.assertTrue('narrativeInfo' in ret)
+            self.assertTrue('workspaceInfo' in ret)
+            info = ret['workspaceInfo']
+            self.assertIn('id', info)
+            self.assertIn('name', info)
+            self.assertIn('owner', info)
+            self.assertIn('moddate', info)
+            self.assertIn('object_count', info)
+            self.assertIn('user_permission', info)
+            self.assertIn('globalread', info)
+            self.assertIn('lockstat', info)
+            self.assertIn('metadata', info)
+            self.assertIn('modDateMs', info)
+            ws_meta = info['metadata']
+            self.assertEqual(ws_meta['is_temporary'], 'true')
+            self.assertEqual(ws_meta['narrative'], str(ret['narrativeInfo']['id']))
+            self.assertNotIn('narrative_nice_name', ws_meta)
+        finally:
+            new_ws_id = ret['workspaceInfo']['id']
+            ws.delete_workspace({'id': new_ws_id})
+
+    @unittest.skip
+    def test_create_new_titled_narrative(self):
+        ws = self.getWsClient()
+        title = "My Test Narrative"
+        ret = self.getImpl().create_new_narrative(self.getContext(), {
+            title: title
+        })
+        try:
+            self.assertTrue('workspaceInfo' in ret)
+            info = ret['workspaceInfo']
+            self.assertIn('id', info)
+            self.assertIn('name', info)
+            self.assertIn('owner', info)
+            self.assertIn('moddate', info)
+            self.assertIn('object_count', info)
+            self.assertIn('user_permission', info)
+            self.assertIn('globalread', info)
+            self.assertIn('lockstat', info)
+            self.assertIn('metadata', info)
+            self.assertIn('modDateMs', info)
+            ws_meta = info['metadata']
+            self.assertEqual(ws_meta['is_temporary'], 'false')
+            self.assertEqual(ws_meta['narrative'], str(ret['narrativeInfo']['id']))
+            self.assertEqual(ws_meta['narrative_nice_name'], title)
         finally:
             new_ws_id = ret['workspaceInfo']['id']
             ws.delete_workspace({'id': new_ws_id})


### PR DESCRIPTION
This has the side effect of setting the workspace metadata keys 'narrative_nice_name' to the title, and 'is_temporary' to false.

Note that if title == 'Untitled' it'll follow the temp narrative behavior. The goal of that design was to avoid having a zillion narratives called 'Untitled.'