### PR TITLE
fix returned appInfo

### DIFF
--- a/lib/NarrativeService/apps/appinfo.py
+++ b/lib/NarrativeService/apps/appinfo.py
@@ -2,7 +2,6 @@ from installed_clients.NarrativeMethodStoreClient import NarrativeMethodStore
 from installed_clients.CatalogClient import Catalog
 
 IGNORE_CATEGORIES = {"inactive", "importers", "viewers"}
-UNUSED_INFO = {'tooltip', 'icon', 'authors', 'app_type', 'namespace'}
 
 
 def get_ignore_categories():
@@ -35,8 +34,6 @@ def get_all_app_info(tag, user, nms_url, catalog_url):
         # ignore empty apps or apps in IGNORE_CATEGORIES
         if not a or not set(a.get('categories')).isdisjoint(IGNORE_CATEGORIES):
             continue
-        # remove unused info
-        [a.pop(key, None) for key in UNUSED_INFO]
         # add short version of input/output types
         for target_type in ['input_types', 'output_types']:
             a['short_{}'.format(target_type)] = _shorten_types(a.get(target_type))

--- a/test/AppInfo_test.py
+++ b/test/AppInfo_test.py
@@ -70,8 +70,9 @@ class AppInfoTestCase(unittest.TestCase):
             self.assertIsNotNone(info['module_versions'][m])
         for a in info['app_infos']:
             app = info['app_infos'][a]['info']
-            self.assertNotIn('app_type', app)
-            self.assertNotIn('authors', app)
+            self.assertIn('app_type', app)
+            self.assertIn('authors', app)
+            self.assertIsInstance(app['authors'], list)
             self.assertIn('categories', app)
             self.assertIsInstance(app['categories'], list)
             for category in IGNORE_CATEGORIES:
@@ -82,14 +83,13 @@ class AppInfoTestCase(unittest.TestCase):
             self.assertIn('short_input_types', app)
             self.assertIsInstance(app['short_input_types'], list)
             self.assertIn('name', app)
-            self.assertNotIn('namespace', app)
+            self.assertIn('namespace', app)
             self.assertIn('output_types', app)
             self.assertIsInstance(app['output_types'], list)
             self.assertIn('short_output_types', app)
             self.assertIsInstance(app['short_output_types'], list)
             self.assertIn('subtitle', app)
-            self.assertNotIn('tooltip', app)
-            self.assertNotIn('icon', app)
+            self.assertIn('tooltip', app)
             self.assertIn('ver', app)
 
     def test_get_ignore_categories_ok(self):


### PR DESCRIPTION
@briehl 

This is the cause of `undefined` category and no icons. I am too young in JS world. I wasn't looking at `kbaseAppCard.js` and `kbaseCatalogBrowser.js` which are imported in `kbaseNarrativeAppPanel.js`. They together use pretty much all app info.  