### PR TITLE
Remove Data Palettes from NarrativeService, round 1

### DIFF
--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -104,6 +104,7 @@ module NarrativeService {
             converted into string).
         types - optional filter field, limiting output list to set of types.
         includeMetadata - if 1, includes object metadata, if 0, does not. Default 0.
+        include_data_palettes - if 1, includes data palette info, if 0, does not. Default 0.
     */
     typedef structure {
         string ws_name;
@@ -111,11 +112,13 @@ module NarrativeService {
         list<string> workspaces;
         list<string> types;
         boolean includeMetadata;
+        boolean include_data_palettes;
     } ListObjectsWithSetsParams;
 
     /*
         data_palette_refs - mapping from workspace Id to reference to DataPalette
-            container existing in given workspace.
+            container existing in given workspace. Not present if include_data_palettes is 0
+            in the input parameters.
     */
     typedef structure {
         list<ListItem> data;

--- a/lib/NarrativeService/NarrativeManager.py
+++ b/lib/NarrativeService/NarrativeManager.py
@@ -516,33 +516,27 @@ class NarrativeManager:
         return ret
 
     def copy_object(self, ref, target_ws_id, target_ws_name, target_name, src_info):
-        # There should be some logic related to DataPalettes
-        if (not target_ws_id) and (not target_ws_name):
-            raise ValueError("Neither target workspace ID nor name is defined")
+        """
+        Copies an object from one workspace to another.
+        """
+        if not target_ws_id and not target_ws_name:
+            raise ValueError("Neither target workspace id nor name is defined")
         if not src_info:
             src_info_tuple = self.ws.get_object_info_new({'objects': [{'ref': ref}],
                                                           'includeMetadata': 0})[0]
             src_info = ServiceUtils.object_info_to_object(src_info_tuple)
-        type_name = src_info['typeModule'] + '.' + src_info['typeName']
-        type_config = self.DATA_PALETTES_TYPES.get(type_name)
-        if type_config is not None:
-            # Copy with DataPaletteService
-            if target_name:
-                raise ValueError("'target_name' cannot be defined for DataPalette copy")
-            target_ws_name_or_id = self._get_workspace_name_or_id(target_ws_id, target_ws_name)
-            self.dps_cache.call_method("add_to_palette", [{'workspace': target_ws_name_or_id,
-                                                           'new_refs': [{'ref': ref}]}],
-                                       self.token)
-            return {'info': src_info}
-        else:
-            if not target_name:
-                target_name = src_info['name']
-            obj_info_tuple = self.ws.copy_object({'from': {'ref': ref},
-                                                  'to': {'wsid': target_ws_id,
-                                                         'workspace': target_ws_name,
-                                                         'name': target_name}})
-            obj_info = ServiceUtils.object_info_to_object(obj_info_tuple)
-            return {'info': obj_info}
+        if not target_name:
+            target_name = src_info['name']
+        obj_info_tuple = self.ws.copy_object({
+            'from': {'ref': ref},
+            'to': {
+                'wsid': target_ws_id,
+                'workspace': target_ws_name,
+                'name': target_name
+            }
+        })
+        obj_info = ServiceUtils.object_info_to_object(obj_info_tuple)
+        return {'info': obj_info}
 
     def list_available_types(self, workspaces):
         data = self.list_objects_with_sets(workspaces=workspaces)['data']

--- a/lib/NarrativeService/NarrativeServiceImpl.py
+++ b/lib/NarrativeService/NarrativeServiceImpl.py
@@ -26,8 +26,8 @@ class NarrativeService:
     # the latter method is running.
     ######################################### noqa
     VERSION = "0.2.1"
-    GIT_URL = "https://github.com/Tianhao-Gu/NarrativeService.git"
-    GIT_COMMIT_HASH = "1a9ec28a5fbc301e62945e12404470c53d62dd52"
+    GIT_URL = "https://github.com/briehl/NarrativeService"
+    GIT_COMMIT_HASH = "d57f119e95cc9b8132ff4993cb0de4e11a0eb3ff"
 
     #BEGIN_CLASS_HEADER
     def _nm(self, ctx):
@@ -65,14 +65,17 @@ class NarrativeService:
            (in case of 'workspaces' each string could be workspace name or ID
            converted into string). types - optional filter field, limiting
            output list to set of types. includeMetadata - if 1, includes
-           object metadata, if 0, does not. Default 0.) -> structure:
-           parameter "ws_name" of String, parameter "ws_id" of Long,
-           parameter "workspaces" of list of String, parameter "types" of
-           list of String, parameter "includeMetadata" of type "boolean"
-           (@range [0,1])
+           object metadata, if 0, does not. Default 0. include_data_palettes
+           - if 1, includes data palette info, if 0, does not. Default 0.) ->
+           structure: parameter "ws_name" of String, parameter "ws_id" of
+           Long, parameter "workspaces" of list of String, parameter "types"
+           of list of String, parameter "includeMetadata" of type "boolean"
+           (@range [0,1]), parameter "include_data_palettes" of type
+           "boolean" (@range [0,1])
         :returns: instance of type "ListObjectsWithSetsOutput"
            (data_palette_refs - mapping from workspace Id to reference to
-           DataPalette container existing in given workspace.) -> structure:
+           DataPalette container existing in given workspace. Not present if
+           include_data_palettes is 0 in the input parameters.) -> structure:
            parameter "data" of list of type "ListItem" (object_info -
            workspace info for object (including set object), set_items -
            optional property listing info for items of set object, dp_info -
@@ -135,9 +138,11 @@ class NarrativeService:
         workspaces = params.get("workspaces")
         types = params.get("types")
         include_metadata = params.get("includeMetadata", 0)
-        returnVal = self._nm(ctx).list_objects_with_sets(ws_id=ws_id, ws_name=ws_name,
-                                                         workspaces=workspaces, types=types,
-                                                         include_metadata=include_metadata)
+        include_data_palettes = params.get("include_data_palettes", 0)
+        returnVal = self._nm(ctx).list_objects_with_sets(
+            ws_id=ws_id, ws_name=ws_name, workspaces=workspaces, types=types,
+            include_metadata=include_metadata, include_data_palettes=include_data_palettes
+        )
         #END list_objects_with_sets
 
         # At some point might do deeper type checking...

--- a/lib/NarrativeService/NarrativeServiceServer.py
+++ b/lib/NarrativeService/NarrativeServiceServer.py
@@ -381,6 +381,10 @@ class Application(object):
                              name='NarrativeService.get_all_app_info',
                              types=[dict])
         self.method_authentication['NarrativeService.get_all_app_info'] = 'none'  # noqa
+        self.rpc_service.add(impl_NarrativeService.get_ignore_categories,
+                             name='NarrativeService.get_ignore_categories',
+                             types=[])
+        self.method_authentication['NarrativeService.get_ignore_categories'] = 'none'  # noqa
         self.rpc_service.add(impl_NarrativeService.status,
                              name='NarrativeService.status',
                              types=[dict])

--- a/test/NarrativeService_server_test.py
+++ b/test/NarrativeService_server_test.py
@@ -590,21 +590,21 @@ class NarrativeServiceTest(unittest.TestCase):
         example_ws = self.__class__.example_ws_name
         ws_name = self.createWs()
         import_ref = self.__class__.example_reads_ref
-        ret = self.getImpl().copy_object(self.getContext(), {'ref': import_ref,
-                                                             'target_ws_name': ws_name})
-        self.assertEqual(example_ws, ret[0]['info']['ws'])
-        target_name = ret[0]['info']['name']
+        copied_object = self.getImpl().copy_object(self.getContext(), {'ref': import_ref,
+                                                                       'target_ws_name': ws_name})
+        self.assertNotEqual(example_ws, copied_object[0]['info']['ws'])
+        target_name = copied_object[0]['info']['name']
         # Let's check that we see reads copy in list_objects_with_sets
         ret = self.getImpl().list_objects_with_sets(self.getContext(),
-                                                    {"ws_name": ws_name,
-                                                     "include_data_palettes": 1})[0]["data"]
+                                                    {"ws_name": ws_name})[0]["data"]
         found = False
         for item in ret:
             obj_info = item["object_info"]
-            if obj_info[7] == example_ws:
-                self.assertTrue('dp_info' in item)
+            if obj_info[1] == target_name:
                 found = True
+                break
         self.assertTrue(found)
+
         # Genome
         import_ref = self.__class__.example_reads_ref
         # target_name = "MyReads.1"

--- a/test/NarrativeService_server_test.py
+++ b/test/NarrativeService_server_test.py
@@ -167,8 +167,26 @@ class NarrativeServiceTest(unittest.TestCase):
                 set_items = item["set_items"]["set_items_info"]
                 self.assertEqual(1, len(set_items))
         self.assertEqual(1, set_count)
+        self.assertNotIn('data_palette_refs', list_ret)
+        ws_id = self.getWsClient().get_workspace_info({"workspace": ws_name1})[0]
+
+        list_ret = self.getImpl().list_objects_with_sets(self.getContext(),
+                                                         {"ws_name": ws_name1,
+                                                          "include_data_palettes": 1})[0]
+        ret = list_ret['data']
+        self.assertTrue(len(ret) > 0)
+        set_count = 0
+        for item in ret:
+            self.assertTrue("object_info" in item)
+            if "set_items" in item:
+                set_count += 1
+                set_items = item["set_items"]["set_items_info"]
+                self.assertEqual(1, len(set_items))
+        self.assertEqual(1, set_count)
         self.assertIn('data_palette_refs', list_ret)
         ws_id = self.getWsClient().get_workspace_info({"workspace": ws_name1})[0]
+
+
         ret2 = self.getImpl().list_objects_with_sets(self.getContext(),
                                                      {"ws_id": ws_id})[0]["data"]
         self.assertEqual(len(ret), len(ret2))
@@ -267,7 +285,8 @@ class NarrativeServiceTest(unittest.TestCase):
             self.assertNotEqual(ws_name, copy_nar_data['metadata']['ws_name'])
             self.assertEqual(copy_nar_name, copy_nar_data['metadata']['name'])
             ret = self.getImpl().list_objects_with_sets(self.getContext(),
-                                                        {"ws_id": copy_ws_id})[0]["data"]
+                                                        {"ws_id": copy_ws_id,
+                                                         "include_data_palettes": 1})[0]["data"]
             dp_found = False
             for item in ret:
                 obj_info = item["object_info"]
@@ -301,7 +320,6 @@ class NarrativeServiceTest(unittest.TestCase):
         try:
             ret = self.getImpl().list_objects_with_sets(self.getContext(),
                                                         {"ws_id": copy_ws_id})[0]["data"]
-            dp_found = False
             for item in ret:
                 obj_info = item["object_info"]
                 if obj_info[7] == reads_ws_name:
@@ -310,7 +328,6 @@ class NarrativeServiceTest(unittest.TestCase):
                     self.assertTrue('refs' in item['dp_info'])
                     self.assertEqual(str(copy_ws_id), item['dp_info']['ref'].split('/')[0])
                     self.assertEqual(reads_obj_name, obj_info[1])
-                    dp_found = True
             self.assertTrue(dp_found)
         finally:
             # Cleaning up new created workspace
@@ -470,7 +487,8 @@ class NarrativeServiceTest(unittest.TestCase):
         copy_ws_id = ret['newWsId']
         try:
             ret = self.getImpl().list_objects_with_sets(self.getContext2(),
-                                                        {"ws_name": str(copy_ws_id)})[0]["data"]
+                                                        {"ws_name": str(copy_ws_id),
+                                                         "include_data_palettes": 1})[0]["data"]
             found = False
             for item in ret:
                 info = item['object_info']
@@ -578,7 +596,8 @@ class NarrativeServiceTest(unittest.TestCase):
         target_name = ret[0]['info']['name']
         # Let's check that we see reads copy in list_objects_with_sets
         ret = self.getImpl().list_objects_with_sets(self.getContext(),
-                                                    {"ws_name": ws_name})[0]["data"]
+                                                    {"ws_name": ws_name,
+                                                     "include_data_palettes": 1})[0]["data"]
         found = False
         for item in ret:
             obj_info = item["object_info"]
@@ -611,7 +630,8 @@ class NarrativeServiceTest(unittest.TestCase):
                              'users': [self.getContext2()['user_id']]})
         # Get ref-path to reads object
         ret = self.getImpl().list_objects_with_sets(self.getContext(),
-                                                    {"ws_name": ws_name1})[0]['data']
+                                                    {"ws_name": ws_name1,
+                                                     "include_data_palettes": 1})[0]['data']
         reads_ref_path = None
         for item in ret:
             if 'dp_info' in item:
@@ -710,7 +730,8 @@ class NarrativeServiceTest(unittest.TestCase):
         # Let's check that we can list and access reads object
         ret = self.getImpl().list_objects_with_sets(self.getContext2(),
                                                     {"ws_name": ws_name2,
-                                                     "includeMetadata": 0})[0]["data"]
+                                                     "includeMetadata": 0,
+                                                     "include_data_palettes": 1})[0]["data"]
         self.assertEqual(1, len(ret))
         item = ret[0]
         self.assertTrue('dp_info' in item)


### PR DESCRIPTION
First steps -
1. Make data palette lookup optional in `list_objects_with_sets`
2. Remove data palette registration in `copy_object` (basically turns into a wrapper for the workspace call)
3. Update tests