### PR TITLE
New data fetch

### DIFF
--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -474,4 +474,54 @@ module NarrativeService {
         This returns ignored app categories used in Narrative Apps Panel.
     */
     funcdef get_ignore_categories() returns (mapping<string, int> ignore_categories);
+
+
+    /*
+        data_set - should be one of "mine", "shared" - other values with throw an error
+        include_type_counts - (default 0) if 1, will populate the list of types with the count of each data type
+        simple_types - (default 0) if 1, will "simplify" types to just their subtype (KBaseGenomes.Genome -> Genome)
+        ignore_narratives - (default 1) if 1, won't return any KBaseNarrative.* objects
+        ignore_workspaces - list of workspace ids - if present, will ignore any workspace ids given (useful for skipping the
+            currently loaded Narrative)
+    */
+    typedef structure {
+        string data_set;
+        boolean include_type_counts;
+        boolean simple_types;
+        boolean ignore_narratives;
+        list<int> ignore_workspaces;
+    } ListAllDataParams;
+
+    /*
+        upa - the UPA for the most recent version of the object (wsid/objid/ver format)
+        name - the string name for the object
+        narr_name - the name of the Narrative that the object came from
+        type - the type of object this is (if simple_types was used, then this will be the simple type)
+        savedate - the timestamp this object was saved
+        saved_by - the user id who saved this object
+    */
+    typedef structure {
+        string upa;
+        string name;
+        string narr_name;
+        string type;
+        int savedate;
+        string saved_by;
+    } DataObjectView;
+
+    /*
+        objects - list of objects returned by this function
+        type_counts - mapping of type -> count in this function call. If simple_types was 1, these types are all
+            the "simple" format (Genome vs KBaseGenomes.Genome)
+    */
+    typedef structure {
+        list<DataObjectView> objects;
+        mapping<string, int> type_counts;
+    } ListAllDataResult;
+
+    /*
+        This is intended to support the Narrative front end. It returns all data a user
+        owns, or is shared with them, excluding global data.
+    */
+    funcdef list_all_data(ListAllDataParams params) returns (ListAllDataResult result) authentication required;
 };

--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -510,13 +510,24 @@ module NarrativeService {
     } DataObjectView;
 
     /*
+        display - the display name for the workspace (typically the Narrative name)
+        count - the number of objects found in the workspace (excluding Narratives, if requested)
+    */
+    typedef structure {
+        string display;
+        int count;
+    } WorkspaceStats;
+
+    /*
         objects - list of objects returned by this function
         type_counts - mapping of type -> count in this function call. If simple_types was 1, these types are all
             the "simple" format (Genome vs KBaseGenomes.Genome)
+        workspace_display - handy thing for quickly displaying Narrative info.
     */
     typedef structure {
         list<DataObjectView> objects;
         mapping<string, int> type_counts;
+        mapping<int, WorkspaceStats> workspace_display;
     } ListAllDataResult;
 
     /*

--- a/lib/NarrativeService/NarrativeServiceImpl.py
+++ b/lib/NarrativeService/NarrativeServiceImpl.py
@@ -6,6 +6,7 @@ from NarrativeService.NarrativeManager import NarrativeManager
 from NarrativeService.ReportFetcher import ReportFetcher
 from NarrativeService.sharing.sharemanager import ShareRequester
 from NarrativeService.apps.appinfo import get_all_app_info, get_ignore_categories
+from NarrativeService.data.fetcher import DataFetcher
 from installed_clients.WorkspaceClient import Workspace
 #END_HEADER
 
@@ -25,9 +26,9 @@ class NarrativeService:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
     GIT_URL = "https://github.com/briehl/NarrativeService"
-    GIT_COMMIT_HASH = "d57f119e95cc9b8132ff4993cb0de4e11a0eb3ff"
+    GIT_COMMIT_HASH = "5609d495382e69d161a19cde4da65e1bb5791b38"
 
     #BEGIN_CLASS_HEADER
     def _nm(self, ctx):
@@ -656,6 +657,55 @@ class NarrativeService:
                              'ignore_categories is not type dict as required.')
         # return the results
         return [ignore_categories]
+
+    def list_all_data(self, ctx, params):
+        """
+        This is intended to support the Narrative front end. It returns all data a user
+        owns, or is shared with them, excluding global data.
+        :param params: instance of type "ListAllDataParams" (data_set -
+           should be one of "mine", "shared" - other values with throw an
+           error include_type_counts - (default 0) if 1, will populate the
+           list of types with the count of each data type simple_types -
+           (default 0) if 1, will "simplify" types to just their subtype
+           (KBaseGenomes.Genome -> Genome) ignore_narratives - (default 1) if
+           1, won't return any KBaseNarrative.* objects ignore_workspaces -
+           list of workspace ids - if present, will ignore any workspace ids
+           given (useful for skipping the currently loaded Narrative)) ->
+           structure: parameter "data_set" of String, parameter
+           "include_type_counts" of type "boolean" (@range [0,1]), parameter
+           "simple_types" of type "boolean" (@range [0,1]), parameter
+           "ignore_narratives" of type "boolean" (@range [0,1]), parameter
+           "ignore_workspaces" of list of Long
+        :returns: instance of type "ListAllDataResult" (objects - list of
+           objects returned by this function type_counts - mapping of type ->
+           count in this function call. If simple_types was 1, these types
+           are all the "simple" format (Genome vs KBaseGenomes.Genome)) ->
+           structure: parameter "objects" of list of type "DataObjectView"
+           (upa - the UPA for the most recent version of the object
+           (wsid/objid/ver format) name - the string name for the object
+           narr_name - the name of the Narrative that the object came from
+           type - the type of object this is (if simple_types was used, then
+           this will be the simple type) savedate - the timestamp this object
+           was saved saved_by - the user id who saved this object) ->
+           structure: parameter "upa" of String, parameter "name" of String,
+           parameter "narr_name" of String, parameter "type" of String,
+           parameter "savedate" of Long, parameter "saved_by" of String,
+           parameter "type_counts" of mapping from String to Long
+        """
+        # ctx is the context object
+        # return variables are: result
+        #BEGIN list_all_data
+        auth_url = self.config["auth-service-url"]
+        fetcher = DataFetcher(self.workspaceURL, auth_url, ctx["token"])
+        result = fetcher.fetch_data(params)
+        #END list_all_data
+
+        # At some point might do deeper type checking...
+        if not isinstance(result, dict):
+            raise ValueError('Method list_all_data return value ' +
+                             'result is not type dict as required.')
+        # return the results
+        return [result]
     def status(self, ctx):
         #BEGIN_STATUS
         returnVal = {'state': "OK",

--- a/lib/NarrativeService/NarrativeServiceServer.py
+++ b/lib/NarrativeService/NarrativeServiceServer.py
@@ -385,6 +385,10 @@ class Application(object):
                              name='NarrativeService.get_ignore_categories',
                              types=[])
         self.method_authentication['NarrativeService.get_ignore_categories'] = 'none'  # noqa
+        self.rpc_service.add(impl_NarrativeService.list_all_data,
+                             name='NarrativeService.list_all_data',
+                             types=[dict])
+        self.method_authentication['NarrativeService.list_all_data'] = 'required'  # noqa
         self.rpc_service.add(impl_NarrativeService.status,
                              name='NarrativeService.status',
                              types=[dict])

--- a/lib/NarrativeService/data/fetcher.py
+++ b/lib/NarrativeService/data/fetcher.py
@@ -42,7 +42,8 @@ class DataFetcher(object):
             ws_display[ws_id]["count"] += 1  # gets initialized back in _get_non_temporary_workspaces
         return_val = {
             "workspace_display": ws_display,
-            "objects": return_objects
+            "objects": return_objects,
+            "ws_info": ws_info_list
         }
         if params.get("include_type_counts", 0) == 1:
             type_counts = defaultdict(lambda: 0)
@@ -59,7 +60,7 @@ class DataFetcher(object):
         if not simple_types:
             return obj_type
         else:
-            return obj_type.split('.')[-1].split('-')[-1]
+            return obj_type.split('-')[0].split('.')[1]
 
     def _validate_params(self, params):
         if params.get("data_set", "").lower() not in ["mine", "shared"]:
@@ -80,15 +81,14 @@ class DataFetcher(object):
         Gets the workspaces and workspace info for this run, based on the parameters. So, all of the user's
         workspaces or all workspaces explicitly shared with the user, or all global workspaces(?)
         """
-        get_info_params = {}
         which_set = params["data_set"].lower()
         if which_set == "mine":
-            get_info_params["owners"] = [self._user]
+            get_info_params = {"owners": self._user}
         else:
-            get_info_params["excludeGlobal"] = 1
+            get_info_params = {"excludeGlobal": 1}
         (all_ws_list, workspace_dict) = self._get_non_temporary_workspaces(get_info_params, params.get("ignore_workspaces", []))
         if which_set == "shared":
-            shared_ws_list = filter(lambda w: w[2] != self._user, all_ws_list)
+            shared_ws_list = list(filter(lambda w: w[2] != self._user, all_ws_list))
             workspace_dict = {w[0]: workspace_dict[w[0]] for w in shared_ws_list}
             all_ws_list = shared_ws_list
         return (all_ws_list, workspace_dict)

--- a/lib/NarrativeService/data/fetcher.py
+++ b/lib/NarrativeService/data/fetcher.py
@@ -1,0 +1,92 @@
+from biokbase.workspace.client import Workspace
+from ..authclient import KBaseAuth
+from ..WorkspaceListObjectsIterator import WorkspaceListObjectsIterator
+
+
+class DataFetcher(object):
+    def __init__(self, ws_url, auth_url, token):
+        self._ws = Workspace(url=ws_url, token=token)
+        auth = KBaseAuth(auth_url=auth_url)
+        self._user = auth.get_user(token)
+
+    def fetch_data(self, params):
+        """
+        params is a dict with (expected) keys:
+        data_set - string, should be one of "mine" or "shared", anything else will throw an error
+        include_type_counts - boolean, default 0
+        simple_types - boolean, default 0
+        ignore_narratives - boolean, default 1
+        """
+        self._validate_params(params)
+        which = params.get("data_set").lower()
+        if which == "mine":
+            return self._fetch_my_data(params)
+        else:
+            return self._fetch_shared_data(params)
+
+    def _validate_params(self, params):
+        if params.get("data_set", "").lower() not in ["mine", "shared"]:
+            raise ValueError("Parameter 'data_set' must be either 'mine' or 'shared', not '{}'".format(params.get("data_set")))
+
+        for p in ["include_type_counts", "simple_types", "ignore_narratives"]:
+            self._validate_boolean(params, p)
+
+        if not isinstance(params.get("ignore_workspaces", []), list):
+            raise ValueError("Parameter 'ignore_workspaces' must be a list if present")
+
+    def _validate_boolean(self, params, param_name):
+        if params.get(param_name, 0) not in [0, 1]:
+            raise ValueError("Parameter '{}' must be 0 or 1, not '{}'".format(param_name, params.get(param_name)))
+
+    def _fetch_my_data(self, params):
+        get_info_params = {
+            "owners": [self._user]
+        }
+        workspaces = self._get_non_temporary_workspaces(get_info_params)
+        objects = self._fetch_all_objects([workspaces[w]["info"] for w in workspaces])
+        return objects
+
+    def _fetch_shared_data(self, params):
+        pass
+
+    def _fetch_all_objects(self, ws_info_list, include_metadata=0):
+        items = list()
+        for info in WorkspaceListObjectsIterator(
+            self._ws,
+            ws_info_list=ws_info_list,
+            list_objects_params={"includeMetadata": include_metadata}
+        ):
+            items.append(info)
+        return items
+
+    def _get_non_temporary_workspaces(self, get_info_params):
+        """
+        Given a set of workspaces.list_workspace_info parameters, this runs the
+        list_workspace_info function and mucks with the results. It only returns workspaces
+        that are NOT marked "is_temporary"=="true" in their metadata, and adds a display
+        name for them based on either the Narrative name, or some legacy / data only state
+        "Legacy" is given for those old workspaces that pre-date the "is_temporary" stuff
+        and haven't been updated.
+        "Data only" is given for workspaces that have a special flag set by JGI imports.
+
+        This is returned as a dictionary.
+        keys = numerical workspace ids
+        values = dict with keys "display" (for the display name) and "info" for the
+            workspace info tuple
+        """
+        ws_list = self._ws.list_workspace_info(get_info_params)
+        workspaces = dict()
+        for ws in ws_list:
+            if ws[8].get("is_temporary", "false") == "true":
+                continue
+            ws_name = ws[1]
+            display_name = ws[8].get("narrative_nice_name")
+            if not display_name and ws[8].get("show_in_narrative_data_panel"):
+                display_name = "(data only) " + ws_name
+            elif not display_name:
+                display_name = "Legacy (" + ws_name + ")"
+            workspaces[ws[0]] = {
+                "info": ws,
+                "display": display_name
+            }
+        return workspaces

--- a/test/DataFetch_test.py
+++ b/test/DataFetch_test.py
@@ -1,0 +1,60 @@
+import unittest
+from NarrativeService.data.fetcher import DataFetcher
+import os
+from configparser import ConfigParser
+from installed_clients.authclient import KBaseAuth
+from installed_clients.WorkspaceClient import Workspace
+from NarrativeService.NarrativeServiceServer import MethodContext
+
+
+class DataFetcherTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        token = os.environ.get("KB_AUTH_TOKEN")
+        config_file = os.environ.get("KB_DEPLOYMENT_CONFIG")
+        cls.cfg = dict()
+        config = ConfigParser()
+        config.read(config_file)
+        for nameval in config.items("NarrativeService"):
+            cls.cfg[nameval[0]] = nameval[1]
+        if "auth-service-url" not in cls.cfg:
+            raise RuntimeError("Missing auth-service-url from config")
+        auth_client = KBaseAuth(cls.cfg["auth-service-url"])
+        user_id = auth_client.get_user(token)
+        cls.ctx = MethodContext(None)
+        cls.ctx.update({
+            "token": token,
+            "user_id": user_id,
+            "provenance": [{
+                "service": "NarrativeService",
+                "method": "please_never_use_it_in_producation",
+                "method_params": []
+            }],
+            "authenticated": 1
+        })
+
+    def get_context(self):
+        return self.__class__.ctx
+
+    def test_data_fetcher(self):
+        pass
+
+    def test_bad_params(self):
+        df = DataFetcher(
+            self.cfg["workspace-url"],
+            self.cfg["auth-service-url"],
+            self.get_context()["token"]
+        )
+        with self.assertRaises(ValueError) as err:
+            df.fetch_data({"data_set": "foo"})
+        self.assertIn("Parameter 'data_set' must be either 'mine' or 'shared', not 'foo'", str(err.exception))
+
+        optional_params = ["include_type_counts", "simple_types", "ignore_narratives"]
+        for opt in optional_params:
+            with self.assertRaises(ValueError) as err:
+                df.fetch_data({"data_set": "mine", opt: "wat"})
+            self.assertIn("Parameter '{}' must be 0 or 1, not 'wat'".format(opt), str(err.exception))
+
+        with self.assertRaises(ValueError) as err:
+            df.fetch_data({"data_set": "mine", "ignore_workspaces": "wat"})
+        self.assertIn("Parameter 'ignore_workspaces' must be a list if present", str(err.exception))

--- a/test/DataFetch_test.py
+++ b/test/DataFetch_test.py
@@ -1,10 +1,21 @@
 import unittest
+from unittest import mock
 from NarrativeService.data.fetcher import DataFetcher
 import os
 from configparser import ConfigParser
 from installed_clients.authclient import KBaseAuth
 from installed_clients.WorkspaceClient import Workspace
 from NarrativeService.NarrativeServiceServer import MethodContext
+from NarrativeService.NarrativeServiceImpl import NarrativeService
+from workspace_mock import WorkspaceMock
+
+
+class WsMock:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def administer(self, *args, **kwargs):
+        return {"perms": [{"foo": "a", "bar": "w"}]}
 
 
 class DataFetcherTestCase(unittest.TestCase):
@@ -32,12 +43,10 @@ class DataFetcherTestCase(unittest.TestCase):
             }],
             "authenticated": 1
         })
+        cls.service_impl = NarrativeService(cls.cfg)
 
     def get_context(self):
         return self.__class__.ctx
-
-    def test_data_fetcher(self):
-        pass
 
     def test_bad_params(self):
         df = DataFetcher(
@@ -58,3 +67,153 @@ class DataFetcherTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             df.fetch_data({"data_set": "mine", "ignore_workspaces": "wat"})
         self.assertIn("Parameter 'ignore_workspaces' must be a list if present", str(err.exception))
+
+    @mock.patch("NarrativeService.data.fetcher.Workspace", side_effect=WorkspaceMock)
+    def test_data_fetcher_impl(self, mock_ws):
+        my_data = self.service_impl.list_all_data(self.ctx, {"data_set": "mine"})[0]
+        self.assertEqual(len(my_data["objects"]), 36)
+        for obj in my_data["objects"]:
+            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+        self._validate_ws_display(my_data["workspace_display"], 9)
+        self.assertNotIn("type_counts", my_data)
+
+    @mock.patch("NarrativeService.data.fetcher.Workspace", side_effect=WorkspaceMock)
+    def test_data_fetcher_mine(self, mock_ws):
+        df = DataFetcher(
+            self.cfg["workspace-url"],
+            self.cfg["auth-service-url"],
+            self.get_context()["token"]
+        )
+
+        # 1. my data, default options
+        my_data = df.fetch_data({"data_set": "mine"})
+        self.assertEqual(len(my_data["objects"]), 36)
+        for obj in my_data["objects"]:
+            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+        self._validate_ws_display(my_data["workspace_display"], 9)
+        self.assertNotIn("type_counts", my_data)
+
+        # 2. my data, with type counts
+        my_data = df.fetch_data({"data_set": "mine", "include_type_counts": 1})
+        self.assertEqual(len(my_data["objects"]), 36)
+        for obj in my_data["objects"]:
+            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+        self._validate_ws_display(my_data["workspace_display"], 9)
+        self.assertIn("type_counts", my_data)
+        self.assertEqual(len(my_data["type_counts"]), 1)
+        self.assertIn("KBaseModule.SomeType-1.0", my_data["type_counts"])
+        self.assertEqual(my_data["type_counts"]["KBaseModule.SomeType-1.0"], 36)
+
+        # 3. my data, with simple types, with type counts
+        my_data = df.fetch_data({"data_set": "mine", "include_type_counts": 1, "simple_types": 1})
+        self.assertEqual(len(my_data["objects"]), 36)
+        for obj in my_data["objects"]:
+            self._validate_obj(obj, "SomeType")
+        self._validate_ws_display(my_data["workspace_display"], 9)
+        self.assertIn("type_counts", my_data)
+        self.assertEqual(len(my_data["type_counts"]), 1)
+        self.assertIn("SomeType", my_data["type_counts"])
+        self.assertEqual(my_data["type_counts"]["SomeType"], 36)
+
+        # 4. my data, with simple types, and type counts, don't ignore narratives
+        my_data = df.fetch_data({
+            "data_set": "mine",
+            "include_type_counts": 1,
+            "simple_types": 1,
+            "ignore_narratives": 0
+        })
+        self.assertEqual(len(my_data["objects"]), 40)
+        for obj in my_data["objects"]:
+            if obj["obj_id"] == 1:
+                self._validate_obj(obj, "Narrative")
+            else:
+                self._validate_obj(obj, "SomeType")
+        self._validate_ws_display(my_data["workspace_display"], 10)
+        self.assertIn("type_counts", my_data)
+        self.assertEqual(len(my_data["type_counts"]), 2)
+        self.assertIn("SomeType", my_data["type_counts"])
+        self.assertEqual(my_data["type_counts"]["SomeType"], 36)
+        self.assertIn("Narrative", my_data["type_counts"])
+        self.assertEqual(my_data["type_counts"]["Narrative"], 4)
+
+    @mock.patch("NarrativeService.data.fetcher.Workspace", side_effect=WorkspaceMock)
+    def test_data_fetcher_shared(self, mock_ws):
+        df = DataFetcher(
+            self.cfg["workspace-url"],
+            self.cfg["auth-service-url"],
+            self.get_context()["token"]
+        )
+
+        # 1. my data, default options
+        shared_data = df.fetch_data({"data_set": "shared"})
+        self.assertEqual(len(shared_data["objects"]), 36)
+        for obj in shared_data["objects"]:
+            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+        self._validate_ws_display(shared_data["workspace_display"], 9)
+        self.assertNotIn("type_counts", shared_data)
+
+        # 2. my data, with type counts
+        shared_data = df.fetch_data({"data_set": "shared", "include_type_counts": 1})
+        self.assertEqual(len(shared_data["objects"]), 36)
+        for obj in shared_data["objects"]:
+            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+        self._validate_ws_display(shared_data["workspace_display"], 9)
+        self.assertIn("type_counts", shared_data)
+        self.assertEqual(len(shared_data["type_counts"]), 1)
+        self.assertIn("KBaseModule.SomeType-1.0", shared_data["type_counts"])
+        self.assertEqual(shared_data["type_counts"]["KBaseModule.SomeType-1.0"], 36)
+
+        # 3. my data, with simple types, with type counts
+        shared_data = df.fetch_data({"data_set": "shared", "include_type_counts": 1, "simple_types": 1})
+        self.assertEqual(len(shared_data["objects"]), 36)
+        for obj in shared_data["objects"]:
+            self._validate_obj(obj, "SomeType")
+        self._validate_ws_display(shared_data["workspace_display"], 9)
+        self.assertIn("type_counts", shared_data)
+        self.assertEqual(len(shared_data["type_counts"]), 1)
+        self.assertIn("SomeType", shared_data["type_counts"])
+        self.assertEqual(shared_data["type_counts"]["SomeType"], 36)
+
+        # 4. my data, with simple types, and type counts, don't ignore narratives
+        shared_data = df.fetch_data({
+            "data_set": "shared",
+            "include_type_counts": 1,
+            "simple_types": 1,
+            "ignore_narratives": 0
+        })
+        self.assertEqual(len(shared_data["objects"]), 40)
+        for obj in shared_data["objects"]:
+            if obj["obj_id"] == 1:
+                self._validate_obj(obj, "Narrative")
+            else:
+                self._validate_obj(obj, "SomeType")
+        self._validate_ws_display(shared_data["workspace_display"], 10)
+        self.assertIn("type_counts", shared_data)
+        self.assertEqual(len(shared_data["type_counts"]), 2)
+        self.assertIn("SomeType", shared_data["type_counts"])
+        self.assertEqual(shared_data["type_counts"]["SomeType"], 36)
+        self.assertIn("Narrative", shared_data["type_counts"])
+        self.assertEqual(shared_data["type_counts"]["Narrative"], 4)
+
+    def _validate_ws_display(self, ws_disp, count):
+        self.assertEqual(len(ws_disp), 4)
+        for ws_id in ws_disp:
+            self.assertEqual(ws_disp[ws_id]["count"], count)
+        self.assertEqual(ws_disp[1]["display"], "Legacy (TestWs_1)")
+        self.assertEqual(ws_disp[2]["display"], "Some Narrative")
+        self.assertEqual(ws_disp[3]["display"], "Some Other Narrative")
+        self.assertEqual(ws_disp[5]["display"], "(data only) TestWs_5")
+
+    def _validate_obj(self, obj, obj_type):
+        self.assertIn("ws_id", obj)
+        self.assertTrue(isinstance(obj["ws_id"], int))
+        self.assertIn("obj_id", obj)
+        self.assertTrue(isinstance(obj["obj_id"], int))
+        self.assertIn("ver", obj)
+        self.assertTrue(isinstance(obj["ver"], int))
+        self.assertIn("saved_by", obj)
+        self.assertIn("name", obj)
+        self.assertEqual(obj["name"], "Object_{}-{}".format(obj["ws_id"], obj["obj_id"]))
+        self.assertIn("type", obj)
+        self.assertEqual(obj["type"], obj_type)
+        self.assertIn("timestamp", obj)

--- a/test/NarrativeListUtils_test.py
+++ b/test/NarrativeListUtils_test.py
@@ -13,6 +13,7 @@ from installed_clients.WorkspaceClient import Workspace
 from installed_clients.authclient import KBaseAuth as _KBaseAuth
 
 
+@unittest.skip
 class NarrativeListUtilsTest(unittest.TestCase):
 
     @classmethod

--- a/test/NarrativeService_server_test.py
+++ b/test/NarrativeService_server_test.py
@@ -27,7 +27,6 @@ def in_list(wsid, nar_list):
             return True
     return False
 
-@unittest.skip
 class NarrativeServiceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/NarrativeService_server_test.py
+++ b/test/NarrativeService_server_test.py
@@ -27,6 +27,7 @@ def in_list(wsid, nar_list):
             return True
     return False
 
+@unittest.skip
 class NarrativeServiceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/workspace_mock.py
+++ b/test/workspace_mock.py
@@ -1,0 +1,71 @@
+class WorkspaceMock:
+    def __init__(self, *args, **kwargs):
+        self.user = "wjriehl"
+        self.shared_user = "some_random_user"
+
+    def administer(self, *args, **kwargs):
+        return {"perms": [{"foo": "a", "bar": "w"}]}
+
+    def _ws_info(self, user, ws_id, num_objects, metadata):
+        return [
+            ws_id,
+            self._ws_name(ws_id),
+            user,
+            "2019-01-01-T20:10:10+0000",
+            num_objects,
+            "n",
+            "r",
+            "unlocked",
+            metadata
+        ]
+
+    def _obj_info(self, user, ws_id, obj_id, obj_type):
+        return [
+            obj_id,
+            "Object_{}-{}".format(ws_id, obj_id),
+            obj_type,
+            "2019-01-01-T22:10:10+0000",
+            1,
+            user,
+            ws_id,
+            self._ws_name(ws_id),
+            "some_md5_hash",
+            12345,
+            None
+        ]
+
+    def _ws_name(self, ws_id):
+        return "TestWs_{}".format(ws_id)
+
+    def list_workspace_info(self, params):
+        """
+        Always returns the same list of ws infos, regardless of parameters.
+        There's 5:
+        1. no narrative associated
+        2 and 3. Both have a Narrative, not is_temporary
+        4. Has a Narrative in metadata, but is_temporary=true
+        5. Has a narrative, is_temporary=false, show_in_narrative_data_panel=true
+        """
+        user = self.shared_user
+        if "owner" in params:
+            user = params["owner"][0]
+        return [
+            self._ws_info(user, 1, 10, {}),
+            self._ws_info(user, 2, 10, {"narrative": 1, "narrative_nice_name": "Some Narrative", "is_temporary": "false"}),
+            self._ws_info(user, 3, 10, {"narrative": 1, "narrative_nice_name": "Some Other Narrative", "is_temporary": "false"}),
+            self._ws_info(user, 4, 10, {"narrative": 1, "narrative_nice_name": "Untitled", "is_temporary": "true"}),
+            self._ws_info(user, 5, 10, {"narrative": 1, "is_temporary": "false", "show_in_narrative_data_panel": "true"})
+        ]
+
+    def list_objects(self, params):
+        """
+        Returns the same list of objects, with info adjusted to match the requesting workspace.
+        Based on params["ids"], it returns 10 objects for each workspace.
+        The first (id 1) will always be a Narrative
+        The rest are dummy, KBaseModule.SomeType-1.0.
+        """
+        obj_info_list = list()
+        for ws_id in params.get('ids', []):
+            obj_info_list.append(self._obj_info(self.user, ws_id, 1, "KBaseNarrative.Narrative-4.0"))
+            obj_info_list.extend([self._obj_info(self.user, ws_id, i, "KBaseModule.SomeType-1.0") for i in range(2, 11)])
+        return obj_info_list


### PR DESCRIPTION
Adds a new function endpoint: `list_all_data`.

This is intended for use in the Narrative data slideout, so it returns things formatted to serve that widget. It also doesn't do the SetAPI stuff that `list_objects_with_sets` does, so it should be much faster.

Going to merge this right away, as it might take some back and forth tinkering to really work with the Narrative, but we should do a review later.