### PR TITLE
Add a "types" option

### DIFF
--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -484,6 +484,8 @@ module NarrativeService {
         include_metadata - (default 0) if 1, includes object metadata
         ignore_workspaces - (optional) list of workspace ids - if present, will ignore any workspace ids given (useful for skipping the
             currently loaded Narrative)
+        limit - (default is 30000) if present, limits returned data objects to the number given. Must be > 0 if present.
+        types - (default null or empty list) if present, will only return the types specified.
     */
     typedef structure {
         string data_set;
@@ -492,6 +494,8 @@ module NarrativeService {
         boolean ignore_narratives;
         boolean include_metadata;
         list<int> ignore_workspaces;
+        int limit;
+        list<string> types;
     } ListAllDataParams;
 
     /*
@@ -522,12 +526,14 @@ module NarrativeService {
 
     /*
         objects - list of objects returned by this function
+        limit_reached - 1 if there are more data objects than given by the limit in params, 0 otherwise
         type_counts - mapping of type -> count in this function call. If simple_types was 1, these types are all
             the "simple" format (Genome vs KBaseGenomes.Genome)
         workspace_display - handy thing for quickly displaying Narrative info.
     */
     typedef structure {
         list<DataObjectView> objects;
+        boolean limit_reached;
         mapping<string, int> type_counts;
         mapping<int, WorkspaceStats> workspace_display;
     } ListDataResult;
@@ -544,6 +550,8 @@ module NarrativeService {
         simple_types - (default 0) if 1, will "simplify" types to just their subtype (KBaseGenomes.Genome -> Genome)
         ignore_narratives - (default 1) if 1, won't return any KBaseNarrative.* objects
         include_metadata - (default 0) if 1, includes object metadata
+        limit - (default is 30000) if present, limits returned data objects to the number given. Must be > 0 if present.
+        types - (default null or empty list) if present, will only return the types specified.
     */
     typedef structure {
         list<int> workspace_ids;
@@ -551,6 +559,8 @@ module NarrativeService {
         boolean simple_types;
         boolean ignore_narratives;
         boolean include_metadata;
+        int limit;
+        list<string> types;
     } ListWorkspaceDataParams;
 
     /*

--- a/lib/NarrativeService/WorkspaceListObjectsIterator.py
+++ b/lib/NarrativeService/WorkspaceListObjectsIterator.py
@@ -3,14 +3,14 @@ from collections import deque
 
 class WorkspaceListObjectsIterator:
 
-    # ws_info - optional workspace info tuple (if is not defined then either ws_id 
+    # ws_info - optional workspace info tuple (if is not defined then either ws_id
     #    or ws_name should be provided),
-    # ws_id/ws_name - optional workspace identification (if neither is defined 
+    # ws_id/ws_name - optional workspace identification (if neither is defined
     #    then ws_info should be provided),
-    # list_objects_params - optional structure with such Woskspace.ListObjectsParams 
+    # list_objects_params - optional structure with such Woskspace.ListObjectsParams
     #    as 'type' or 'before', 'after', 'showHidden', 'includeMetadata' and so on,
     #    wherein there is no need to set 'ids' or 'workspaces' or 'min/maxObjectID'.
-    def __init__(self, ws_client, ws_info_list = None, ws_id = None, ws_name = None, 
+    def __init__(self, ws_client, ws_info_list = None, ws_id = None, ws_name = None,
                  list_objects_params = {}, part_size = 10000, global_limit = 100000):
         self.ws = ws_client
         if not ws_info_list:
@@ -51,7 +51,7 @@ class WorkspaceListObjectsIterator:
         while self.part_iter is not None:
             try:
                 self.total_counter += 1
-                if self.total_counter > self.global_limit:
+                if self.global_limit is not None and self.total_counter > self.global_limit:
                     raise StopIteration
                 return next(self.part_iter)
             except StopIteration:

--- a/test/DataFetch_test.py
+++ b/test/DataFetch_test.py
@@ -68,6 +68,16 @@ class DataFetcherTestCase(unittest.TestCase):
             df.fetch_accessible_data({"data_set": "mine", "ignore_workspaces": "wat"})
         self.assertIn("Parameter 'ignore_workspaces' must be a list if present", str(err.exception))
 
+        bad_limits = [0, -5, "a", "foo", ["foo", "bar"], {"no": "wai"}]
+        for bad in bad_limits:
+            with self.assertRaises(ValueError) as err:
+                df.fetch_accessible_data({"data_set": "mine", "limit": bad})
+            self.assertIn("Parameter 'limit' must be an integer > 0", str(err.exception))
+
+        with self.assertRaises(ValueError) as err:
+            df.fetch_accessible_data({"data_set": "mine", "types": "wat"})
+        self.assertIn("Parameter 'types' must be a list if present.", str(err.exception))
+
     def test_fetch_specific_bad_params(self):
         df = DataFetcher(
             self.cfg["workspace-url"],
@@ -96,12 +106,22 @@ class DataFetcherTestCase(unittest.TestCase):
                 df.fetch_specific_workspace_data({"workspace_ids": [1, 2], opt: "wat"})
             self.assertIn("Parameter '{}' must be 0 or 1, not 'wat'".format(opt), str(err.exception))
 
+        bad_limits = [0, -5, "a", "foo", ["foo", "bar"], {"no": "wai"}]
+        for bad in bad_limits:
+            with self.assertRaises(ValueError) as err:
+                df.fetch_specific_workspace_data({"workspace_ids": [1], "limit": bad})
+            self.assertIn("Parameter 'limit' must be an integer > 0", str(err.exception))
+
+        with self.assertRaises(ValueError) as err:
+            df.fetch_specific_workspace_data({"workspace_ids": [1], "types": "wat"})
+        self.assertIn("Parameter 'types' must be a list if present.", str(err.exception))
+
     @mock.patch("NarrativeService.data.fetcher.Workspace", side_effect=WorkspaceMock)
     def test_list_all_data_impl(self, mock_ws):
         my_data = self.service_impl.list_all_data(self.ctx, {"data_set": "mine"})[0]
         self.assertEqual(len(my_data["objects"]), 36)
         for obj in my_data["objects"]:
-            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+            self._validate_obj(obj, "KBaseModule.SomeType")
         self._validate_ws_display(my_data["workspace_display"], 9)
         self.assertNotIn("type_counts", my_data)
 
@@ -110,7 +130,7 @@ class DataFetcherTestCase(unittest.TestCase):
         my_data = self.service_impl.list_workspace_data(self.ctx, {"workspace_ids": [1, 2, 3, 5]})[0]
         self.assertEqual(len(my_data["objects"]), 36)
         for obj in my_data["objects"]:
-            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+            self._validate_obj(obj, "KBaseModule.SomeType")
         self._validate_ws_display(my_data["workspace_display"], 9)
         self.assertNotIn("type_counts", my_data)
 
@@ -126,7 +146,7 @@ class DataFetcherTestCase(unittest.TestCase):
         my_data = df.fetch_accessible_data({"data_set": "mine"})
         self.assertEqual(len(my_data["objects"]), 36)
         for obj in my_data["objects"]:
-            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+            self._validate_obj(obj, "KBaseModule.SomeType")
         self._validate_ws_display(my_data["workspace_display"], 9)
         self.assertNotIn("type_counts", my_data)
 
@@ -134,12 +154,12 @@ class DataFetcherTestCase(unittest.TestCase):
         my_data = df.fetch_accessible_data({"data_set": "mine", "include_type_counts": 1})
         self.assertEqual(len(my_data["objects"]), 36)
         for obj in my_data["objects"]:
-            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+            self._validate_obj(obj, "KBaseModule.SomeType")
         self._validate_ws_display(my_data["workspace_display"], 9)
         self.assertIn("type_counts", my_data)
-        self.assertEqual(len(my_data["type_counts"]), 1)
+        self.assertEqual(len(my_data["type_counts"]), 9)  # one for each version of SomeType
         self.assertIn("KBaseModule.SomeType-1.0", my_data["type_counts"])
-        self.assertEqual(my_data["type_counts"]["KBaseModule.SomeType-1.0"], 36)
+        self.assertEqual(my_data["type_counts"]["KBaseModule.SomeType-1.0"], 4)
 
         # 3. my data, with simple types, with type counts
         my_data = df.fetch_accessible_data({"data_set": "mine", "include_type_counts": 1, "simple_types": 1})
@@ -181,26 +201,26 @@ class DataFetcherTestCase(unittest.TestCase):
             self.get_context()["token"]
         )
 
-        # 1. my data, default options
+        # 1. shared data, default options
         shared_data = df.fetch_accessible_data({"data_set": "shared"})
         self.assertEqual(len(shared_data["objects"]), 36)
         for obj in shared_data["objects"]:
-            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+            self._validate_obj(obj, "KBaseModule.SomeType")
         self._validate_ws_display(shared_data["workspace_display"], 9)
         self.assertNotIn("type_counts", shared_data)
 
-        # 2. my data, with type counts
+        # 2. shared data, with type counts
         shared_data = df.fetch_accessible_data({"data_set": "shared", "include_type_counts": 1})
         self.assertEqual(len(shared_data["objects"]), 36)
         for obj in shared_data["objects"]:
-            self._validate_obj(obj, "KBaseModule.SomeType-1.0")
+            self._validate_obj(obj, "KBaseModule.SomeType")
         self._validate_ws_display(shared_data["workspace_display"], 9)
         self.assertIn("type_counts", shared_data)
-        self.assertEqual(len(shared_data["type_counts"]), 1)
+        self.assertEqual(len(shared_data["type_counts"]), 9)  # one for each version of SomeType
         self.assertIn("KBaseModule.SomeType-1.0", shared_data["type_counts"])
-        self.assertEqual(shared_data["type_counts"]["KBaseModule.SomeType-1.0"], 36)
+        self.assertEqual(shared_data["type_counts"]["KBaseModule.SomeType-1.0"], 4)
 
-        # 3. my data, with simple types, with type counts
+        # 3. shared data, with simple types, with type counts
         shared_data = df.fetch_accessible_data({"data_set": "shared", "include_type_counts": 1, "simple_types": 1})
         self.assertEqual(len(shared_data["objects"]), 36)
         for obj in shared_data["objects"]:
@@ -211,7 +231,7 @@ class DataFetcherTestCase(unittest.TestCase):
         self.assertIn("SomeType", shared_data["type_counts"])
         self.assertEqual(shared_data["type_counts"]["SomeType"], 36)
 
-        # 4. my data, with simple types, and type counts, don't ignore narratives
+        # 4. shared data, with simple types, and type counts, don't ignore narratives
         shared_data = df.fetch_accessible_data({
             "data_set": "shared",
             "include_type_counts": 1,
@@ -231,6 +251,86 @@ class DataFetcherTestCase(unittest.TestCase):
         self.assertEqual(shared_data["type_counts"]["SomeType"], 36)
         self.assertIn("Narrative", shared_data["type_counts"])
         self.assertEqual(shared_data["type_counts"]["Narrative"], 4)
+
+    @mock.patch("NarrativeService.data.fetcher.Workspace", side_effect=WorkspaceMock)
+    def test_data_fetcher_specific_types(self, mock_ws):
+        df = DataFetcher(
+            self.cfg["workspace-url"],
+            self.cfg["auth-service-url"],
+            self.get_context()["token"]
+        )
+
+        # 1. ws 1,2,3,5, default options, include Narratives, but only return KBaseModule.SomeType
+        data = df.fetch_specific_workspace_data({
+            "workspace_ids": [1, 2, 3, 5],
+            "ignore_narratives": 0,
+            "types": ["KBaseModule.SomeType"]
+        })
+        self.assertEqual(len(data["objects"]), 36)
+        for obj in data["objects"]:
+            self._validate_obj(obj, "KBaseModule.SomeType")
+        self._validate_ws_display(data["workspace_display"], 9)
+        self.assertNotIn("type_counts", data)
+
+        # 2. ws 1,2,3,5, default options, include Narratives, but only return KBaseNarrative.Narrative
+        data = df.fetch_specific_workspace_data({
+            "workspace_ids": [1, 2, 3, 5],
+            "ignore_narratives": 0,
+            "types": ["KBaseNarrative.Narrative"]
+        })
+        self.assertEqual(len(data["objects"]), 4)
+        for obj in data["objects"]:
+            self._validate_obj(obj, "KBaseNarrative.Narrative-4.0")
+        self._validate_ws_display(data["workspace_display"], 1)
+        self.assertNotIn("type_counts", data)
+
+        # 3. ws 1,2,3,5, default options, include Narratives and SomeType, so return everything
+        data = df.fetch_specific_workspace_data({
+            "workspace_ids": [1, 2, 3, 5],
+            "ignore_narratives": 0,
+            "types": ["KBaseNarrative.Narrative", "KBaseModule.SomeType"]
+        })
+        self.assertEqual(len(data["objects"]), 40)
+        for obj in data["objects"]:
+            if obj["obj_id"] == 1:
+                self._validate_obj(obj, "KBaseNarrative.Narrative-4.0")
+            else:
+                self._validate_obj(obj, "KBaseModule.SomeType")
+        self._validate_ws_display(data["workspace_display"], 10)
+        self.assertNotIn("type_counts", data)
+
+
+    @mock.patch("NarrativeService.data.fetcher.Workspace", side_effect=WorkspaceMock)
+    def test_data_fetcher_shared_types(self, mock_ws):
+        df = DataFetcher(
+            self.cfg["workspace-url"],
+            self.cfg["auth-service-url"],
+            self.get_context()["token"]
+        )
+
+        # 1. shared data, default options, include Narratives, but only return KBaseModule.SomeType
+        shared_data = df.fetch_accessible_data({
+            "data_set": "shared",
+            "ignore_narratives": 0,
+            "types": ["KBaseModule.SomeType"]
+        })
+        self.assertEqual(len(shared_data["objects"]), 36)
+        for obj in shared_data["objects"]:
+            self._validate_obj(obj, "KBaseModule.SomeType")
+        self._validate_ws_display(shared_data["workspace_display"], 9)
+        self.assertNotIn("type_counts", shared_data)
+
+        # 2. shared data, default options, include Narratives, but only return KBaseNarrative.Narrative
+        shared_data = df.fetch_accessible_data({
+            "data_set": "shared",
+            "ignore_narratives": 0,
+            "types": ["KBaseNarrative.Narrative"]
+        })
+        self.assertEqual(len(shared_data["objects"]), 4)
+        for obj in shared_data["objects"]:
+            self._validate_obj(obj, "KBaseNarrative.Narrative-4.0")
+        self._validate_ws_display(shared_data["workspace_display"], 1)
+        self.assertNotIn("type_counts", shared_data)
 
     def _validate_ws_display(self, ws_disp, count):
         self.assertEqual(len(ws_disp), 4)
@@ -252,5 +352,5 @@ class DataFetcherTestCase(unittest.TestCase):
         self.assertIn("name", obj)
         self.assertEqual(obj["name"], "Object_{}-{}".format(obj["ws_id"], obj["obj_id"]))
         self.assertIn("type", obj)
-        self.assertEqual(obj["type"], obj_type)
+        self.assertIn(obj_type, obj["type"])
         self.assertIn("timestamp", obj)

--- a/test/NarrativeService_server_test.py
+++ b/test/NarrativeService_server_test.py
@@ -27,7 +27,7 @@ def in_list(wsid, nar_list):
             return True
     return False
 
-@unittest.skip
+# @unittest.skip
 class NarrativeServiceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/NarrativeService_server_test.py
+++ b/test/NarrativeService_server_test.py
@@ -27,6 +27,7 @@ def in_list(wsid, nar_list):
             return True
     return False
 
+@unittest.skip
 class NarrativeServiceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/workspace_mock.py
+++ b/test/workspace_mock.py
@@ -76,10 +76,10 @@ class WorkspaceMock:
         Returns the same list of objects, with info adjusted to match the requesting workspace.
         Based on params["ids"], it returns 10 objects for each workspace.
         The first (id 1) will always be a Narrative
-        The rest are dummy, KBaseModule.SomeType-1.0.
+        The rest are dummy, KBaseModule.SomeType-N.0. where N ranges from 1 - 10 (for each id. so we can test version collapsing.)
         """
         obj_info_list = list()
         for ws_id in params.get('ids', []):
             obj_info_list.append(self._obj_info(self.user, ws_id, 1, "KBaseNarrative.Narrative-4.0"))
-            obj_info_list.extend([self._obj_info(self.user, ws_id, i, "KBaseModule.SomeType-1.0") for i in range(2, 11)])
+            obj_info_list.extend([self._obj_info(self.user, ws_id, i, f"KBaseModule.SomeType-{i-1}.0") for i in range(2, 11)])
         return obj_info_list


### PR DESCRIPTION
You can now provide a "types" key  (list of types where each element is "Module.Type", versions are lumped together)

"limit" is included as a key, not used yet.