### PR TITLE
Fix empty lists of workspaces throwing an error

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.2.4
+    0.2.5
 
 owners:
     [wjriehl, tgu2]

--- a/lib/NarrativeService/WorkspaceListObjectsIterator.py
+++ b/lib/NarrativeService/WorkspaceListObjectsIterator.py
@@ -10,17 +10,16 @@ class WorkspaceListObjectsIterator:
     # list_objects_params - optional structure with such Woskspace.ListObjectsParams
     #    as 'type' or 'before', 'after', 'showHidden', 'includeMetadata' and so on,
     #    wherein there is no need to set 'ids' or 'workspaces' or 'min/maxObjectID'.
-    def __init__(self, ws_client, ws_info_list = None, ws_id = None, ws_name = None,
-                 list_objects_params = {}, part_size = 10000, global_limit = 100000):
+    def __init__(self, ws_client, ws_info_list=None, ws_id=None, ws_name=None,
+                 list_objects_params={}, part_size=10000, global_limit=100000):
         self.ws = ws_client
-        if not ws_info_list:
-            if (not ws_id) and (not ws_name):
-                raise ValueError("In case ws_info_list is not set either ws_id or " +
-                                 "ws_name should be set")
+        if ws_info_list is None:
+            if ws_id is None and ws_name is None:
+                raise ValueError("In case ws_info_list is not set either ws_id or ws_name should be set")
             ws_info_list = [self.ws.get_workspace_info({"id": ws_id, "workspace": ws_name})]
         # Let's split workspaces into blocks
-        blocks = [] # Each block is array of ws_info
-        sorted_ws_info_deque = deque(sorted(ws_info_list, key = lambda x: x[4]))
+        blocks = []  # Each block is array of ws_info
+        sorted_ws_info_deque = deque(sorted(ws_info_list, key=lambda x: x[4]))
         while sorted_ws_info_deque:
             block_size = 0
             block = []
@@ -41,7 +40,6 @@ class WorkspaceListObjectsIterator:
         self.global_limit = global_limit
         self.total_counter = 0
         self.part_iter = self._load_next_part()
-        pass
 
     # iterator implementation
     def __iter__(self):

--- a/test/DataFetch_test.py
+++ b/test/DataFetch_test.py
@@ -7,7 +7,10 @@ from installed_clients.authclient import KBaseAuth
 from installed_clients.WorkspaceClient import Workspace
 from NarrativeService.NarrativeServiceServer import MethodContext
 from NarrativeService.NarrativeServiceImpl import NarrativeService
-from workspace_mock import WorkspaceMock
+from workspace_mock import (
+    WorkspaceMock,
+    EmptyWorkspaceMock
+)
 
 
 class WsMock:
@@ -348,6 +351,22 @@ class DataFetcherTestCase(unittest.TestCase):
         })
         self.assertEqual(data["limit_reached"], 1)
         self.assertEqual(len(data["objects"]), limit)
+
+    @mock.patch("NarrativeService.data.fetcher.Workspace", side_effect=EmptyWorkspaceMock)
+    def test_fetch_data_no_ws(self, mock_ws):
+        df = DataFetcher(
+            self.cfg["workspace-url"],
+            self.cfg["auth-service-url"],
+            self.get_context()["token"]
+        )
+
+        data = df.fetch_accessible_data({"data_set": "mine", "limit": 30000})
+        self.assertEqual(data["limit_reached"], 0)
+        self.assertEqual(len(data["objects"]), 0)
+
+        data = df.fetch_accessible_data({"data_set": "shared", "limit": 30000})
+        self.assertEqual(data["limit_reached"], 0)
+        self.assertEqual(len(data["objects"]), 0)
 
     def _validate_ws_display(self, ws_disp, count):
         self.assertEqual(len(ws_disp), 4)

--- a/test/workspace_mock.py
+++ b/test/workspace_mock.py
@@ -1,3 +1,12 @@
+class EmptyWorkspaceMock:
+    def __init__(self, *args, **kwargs):
+        self.user = "some_user"
+        self.shared_user = "some_other_user"
+
+    def list_workspace_info(self, params):
+        return []
+
+
 class WorkspaceMock:
     ws_info_meta = {
         1: {},


### PR DESCRIPTION
If a user without any non-temporary workspaces tries to open their data pane, this was occasionally throwing an error. This is particularly problematic for new users.