### PR TITLE
update links in intro cell

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.3.0
+    0.3.1
 
 owners:
     [wjriehl, tgu2]

--- a/local_data/welcome-cell-content.md
+++ b/local_data/welcome-cell-content.md
@@ -1,17 +1,17 @@
 ## Welcome to KBase's Narrative Interface!
 
-**What's a Narrative?** Narratives are shareable, reproducible workflows that can include data, analysis steps, results, visualizations and commentary. [Learn more...](http://kbase.us/narrative-guide)
+**What's a Narrative?** Narratives are shareable, reproducible workflows that can include data, analysis steps, results, visualizations and commentary. [Learn more...](https://docs.kbase.us/getting-started/narrative)
 
 **Take the Tour:** Choose "Narrative Tour" from the "Help" menu above. The tour walks you through the user interface, pointing out various useful aspects of it.
 
-**Get Some Data:** Click the Add Data button in the Data Panel to search KBase data or upload your own. Hover over a data object to reveal a button for adding it to your Narrative. [Learn more...](http://kbase.us/narrative-guide/explore-data)
+**Get Some Data:** Click the Add Data button in the Data Panel to search KBase data or upload your own. Hover over a data object to reveal a button for adding it to your Narrative. [Learn more...](https://docs.kbase.us/getting-started/narrative/explore-data)
 
-**Analyze It:** Use the Apps panel or the App Catalog to browse available analysis apps. Select an app to add it to your Narrative, fill in the fields, and click the "Run" button to launch the app. [Learn more...](http://kbase.us/narrative-guide/browse-apps-and-methods)
+**Analyze It:** Use the Apps panel or the App Catalog to browse available analysis apps. Select an app to add it to your Narrative, fill in the fields, and click the "Run" button to launch the app. [Learn more...](https://docs.kbase.us/getting-started/narrative/add-apps)
 
-**Save and Share Your Narrative:** Be sure to save your Narrative frequently. To let collaborators view your analysis steps and results, click the Share button. Or make your Narrative public and help expand the social web that KBase is building to make systems biology research more open, reproducible and collaborative. [Learn more...](http://kbase.us/narrative-guide/share-narratives/)
+**Save and Share Your Narrative:** Be sure to save your Narrative frequently. To let collaborators view your analysis steps and results, click the Share button. Or make your Narrative public and help expand the social web that KBase is building to make systems biology research more open, reproducible and collaborative. [Learn more...](https://docs.kbase.us/getting-started/narrative/share)
 
-**Find Documentation:** For more information, please see the [Narrative Interface User Guide](http://kbase.us/narrative-guide) or the [tutorials](http://kbase.us/tutorials).
+**Find Documentation:** For more information, please see the [Narrative Interface User Guide](https://docs.kbase.us/getting-started/narrative) or the [tutorials](https://www.kbase.us/learn/).
 
-**Questions? Bug reports?** [Contact us](http://kbase.us/contact-us)!
+**Questions? Bug reports?** [Contact us](https://www.kbase.us/support/)!
 
 > Ready to begin adding to your Narrative? You can keep this Welcome cell or delete it by selecting "Delete cell" from the "..." menu in the top right corner of this cell.


### PR DESCRIPTION
New marketing site = new links from introduction cell to documentation.

Eventually we'll probably do away with this cell, or make it more optional, but until then it might as well work right.