### PR TITLE
Adds method that returns narrative data in the same format as Search API

### DIFF
--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -612,4 +612,87 @@ module NarrativeService {
         If all this goes off well, the new narrative UPA is returned.
     */
     funcdef rename_narrative(RenameNarrativeParams params) returns (RenameNarrativeResult result) authentication required;
+
+    /*
+        narrative_upa - UPA of the narrative to be requested in search doc format.
+    */
+    typedef structure {
+        string narrative_upa;
+    } SearchDocNarrativeParams;
+
+    /*
+        desc - a brief description of the narrative cell.
+        cell_type - the type of cell.
+        count - the number of instances this cell appears within a given narrative.
+    */
+    typedef structure {
+        string desc;
+        string cell_type;
+        int count;
+    } DocCell;
+
+    /*
+        name - The name of the data object.
+        obj_type - The type of data object.
+        readableType - The data object type in a human readable format for displays.
+    */
+    typedef structure {
+        string name;
+        string obj_type;
+        string readableType;
+    } DocDataObject;
+
+    /*
+        access_group - A numeric ID which corresponds to the ownership group.
+        cells - A list of each cell's metadata within a given narrative.
+        copied - Indicates whether this narrative is a copy.
+        creation_date - The date this narrative was created.
+        creator - The username of the creator of a given narrative.
+        data_objects - A list of each data object used in a given narrative.
+        is_narratorial - Whether or not the doc item is narratorial.
+        is_public - Whether or not a given narrative is publicly shared.
+        is_temporary - Whether or not a given narrative exists permanently.
+        modified_at - The date a given narrative was last updated according to the version provided in the UPA param.
+        narrative_title - The title of a given narrative.
+        obj_id - The id of a given narrative
+        obj_name - The name of a given narrative
+        obj_type_module - 
+        obj_type_version - 
+        owner - The username of the current owner of a given narrative.
+        shared_users - A list of users who are allowed access to a given narrative.
+        tags - A list of all tagged versions of a given narrative ???
+        timestamp - The time that a given narrative was last saved, regardless of version.
+        total_cells - The total number of cells in a given narrative.
+        version - The version of the narrative requested
+    */
+    typedef structure {
+        int access_group;
+        list<DocCell> cells;
+        boolean copied;
+        string creation_date;
+        string creator;
+        list<DocDataObject> data_objects;
+        boolean is_narratorial;
+        boolean is_public;
+        boolean is_temporary;
+        int modified_at;
+        string narrative_title;
+        int obj_id;
+        string obj_name;
+        string obj_type_module;
+        string obj_type_version;
+        string owner;
+        list<string> shared_users;
+        list<string> tags;
+        int timestamp;
+        int total_cells;
+        int version;
+    } SearchDocResult;
+
+    /*
+        Intended to return data of previous versions of a given narrative in the same format returned from Search.
+        Formats a call to workspace service to fit the appropriate schema that is intended for use in UI displays
+        in the narrative navigator.
+    */
+    funcdef get_narrative_doc(SearchDocNarrativeParams params) returns (SearchDocResult result) authentication required;
 };

--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -622,13 +622,11 @@ module NarrativeService {
 
     /*
         desc - a brief description of the narrative cell.
-        cell_type - the type of cell.
-        count - the number of instances this cell appears within a given narrative.
+        cell_type - the type of cell. Can be of type 'markdown', 'widget', 'data', 'kbase_app', 'code_cell', or '' if type is not determined.
     */
     typedef structure {
         string desc;
         string cell_type;
-        int count;
     } DocCell;
 
     /*
@@ -646,13 +644,13 @@ module NarrativeService {
         access_group - A numeric ID which corresponds to the ownership group.
         cells - A list of each cell's metadata within a given narrative.
         copied - Indicates whether this narrative is a copy.
-        creation_date - The date this narrative was created.
+        creation_date - The date this narrative was created (ISO 8601).
         creator - The username of the creator of a given narrative.
         data_objects - A list of each data object used in a given narrative.
         is_narratorial - Whether or not the doc item is narratorial.
         is_public - Whether or not a given narrative is publicly shared.
         is_temporary - Whether or not a given narrative exists permanently.
-        modified_at - The date a given narrative was last updated according to the version provided in the UPA param.
+        modified_at - The date a given narrative was last updated according to the version provided in the UPA param (ms since epoch).
         narrative_title - The title of a given narrative.
         obj_id - The id of a given narrative
         obj_name - The name of a given narrative
@@ -692,7 +690,7 @@ module NarrativeService {
     /*
         Intended to return data of previous versions of a given narrative in the same format returned from Search.
         Formats a call to workspace service to fit the appropriate schema that is intended for use in UI displays
-        in the narrative navigator.
+        in the narrative navigator. Raises error is "narrative_upa" param is not in specified <workspace_id/obj_id/version> format.
     */
     funcdef get_narrative_doc(SearchDocNarrativeParams params) returns (SearchDocResult result) authentication required;
 };

--- a/NarrativeService.spec
+++ b/NarrativeService.spec
@@ -643,22 +643,14 @@ module NarrativeService {
     /*
         access_group - A numeric ID which corresponds to the ownership group.
         cells - A list of each cell's metadata within a given narrative.
-        copied - Indicates whether this narrative is a copy.
         creation_date - The date this narrative was created (ISO 8601).
         creator - The username of the creator of a given narrative.
         data_objects - A list of each data object used in a given narrative.
-        is_narratorial - Whether or not the doc item is narratorial.
         is_public - Whether or not a given narrative is publicly shared.
-        is_temporary - Whether or not a given narrative exists permanently.
         modified_at - The date a given narrative was last updated according to the version provided in the UPA param (ms since epoch).
         narrative_title - The title of a given narrative.
         obj_id - The id of a given narrative
-        obj_name - The name of a given narrative
-        obj_type_module - 
-        obj_type_version - 
-        owner - The username of the current owner of a given narrative.
         shared_users - A list of users who are allowed access to a given narrative.
-        tags - A list of all tagged versions of a given narrative ???
         timestamp - The time that a given narrative was last saved, regardless of version.
         total_cells - The total number of cells in a given narrative.
         version - The version of the narrative requested
@@ -666,22 +658,15 @@ module NarrativeService {
     typedef structure {
         int access_group;
         list<DocCell> cells;
-        boolean copied;
         string creation_date;
         string creator;
         list<DocDataObject> data_objects;
-        boolean is_narratorial;
         boolean is_public;
-        boolean is_temporary;
         int modified_at;
         string narrative_title;
         int obj_id;
-        string obj_name;
-        string obj_type_module;
-        string obj_type_version;
         string owner;
         list<string> shared_users;
-        list<string> tags;
         int timestamp;
         int total_cells;
         int version;
@@ -690,7 +675,10 @@ module NarrativeService {
     /*
         Intended to return data of previous versions of a given narrative in the same format returned from Search.
         Formats a call to workspace service to fit the appropriate schema that is intended for use in UI displays
-        in the narrative navigator. Raises error is "narrative_upa" param is not in specified <workspace_id/obj_id/version> format.
+        in the narrative navigator. Raises error is "narrative_upa" param is not in specified <workspace_id/obj_id/version> format. 
+        Note that this method is currently to support the UI only, and does not return the full result of a search call,
+        and the following fields are omitted: boolean copied, boolean is_narratorial, boolean is_temporary, string obj_name, string obj_type_module,
+        string obj_type_version, list<string> tags.
     */
     funcdef get_narrative_doc(SearchDocNarrativeParams params) returns (SearchDocResult result) authentication required;
 };

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+
+## v0.3.4
+* Add `get_narrative_doc` method that returns narrative data in the same format as the Search API results
 ## v0.3.3
 * Fixed unittests and added GHA
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.3.4
+    0.4.0
 
 owners:
     [wjriehl, tgu2]

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.3.3
+    0.3.4
 
 owners:
     [wjriehl, tgu2]

--- a/lib/NarrativeService/NarrativeManager.py
+++ b/lib/NarrativeService/NarrativeManager.py
@@ -29,7 +29,6 @@ class NarrativeManager:
         self.intro_cell_file = config["intro-cell-file"]
 
     def get_narrative_doc(self, ws_id, narrative_upa):
-        # data = self.ws.get_objects2({'objects': [{'ref': narrative_upa}]})['data'][0]
         obj_data = self.ws.get_objects2({'objects': [{'ref': narrative_upa}]})
         data_objects = self.ws.list_objects({'ids': [ws_id]})
 

--- a/lib/NarrativeService/NarrativeManager.py
+++ b/lib/NarrativeService/NarrativeManager.py
@@ -44,7 +44,9 @@ class NarrativeManager:
             'shared_users': shared_users,
             'is_public': is_public,
             'timestamp': obj_data['epoch'],
-            'creation_date': obj_data['created']
+            'creation_date': obj_data['created'],
+            'narrative_title': obj_data['data'][0]['data']['metadata'].get('name', ''),
+            'version': obj_data['data'][0]['info'][4]
         }
 
         return doc

--- a/lib/NarrativeService/NarrativeManager.py
+++ b/lib/NarrativeService/NarrativeManager.py
@@ -63,36 +63,45 @@ class NarrativeManager:
 
     def _get_doc_cell(self, cell):
         # get the appropriate cell format for search result doc
-        meta = cell['metadata']['kbase']
+        meta = cell.get('metadata', {}).get('kbase', {})
         if cell['cell_type'] == 'markdown':
             # type markdown
             return {
                 'cell_type': 'markdown',
-                'desc': meta['attributes']['title']
+                'desc': meta.get('attributes', {})
+                            .get('title', 'Markdown Cell')
             }
         elif meta['type'] == 'output':
             # type widget
             return {
                 'cell_type': 'widget',
-                'desc': meta['outputCell']['widget']['name']
+                'desc': meta.get('outputCell', {})
+                            .get('widget', {})
+                            .get('name', 'Widget')
             }
         elif meta['type'] == 'data':
             # type data
             return {
                 'cell_type': 'data',
-                'desc': meta['dataCell']['objectInfo']['name']
+                'desc': meta.get('dataCell', {})
+                            .get('objectInfo', {})
+                            .get('name', 'Data Cell')
             }
         elif meta['type'] == 'app':
             # type kbase_app
             return {
                 'cell_type': 'kbase_app',
-                'desc': meta['appCell']['app']['spec']['info']['name']
+                'desc': meta.get('appCell')
+                            .get('app', {})
+                            .get('spec', {})
+                            .get('info', {})
+                            .get('name', 'KBase App')
             }
         elif meta['type'] == 'code':
             # type code_cell
             return {
                 'cell_type': 'code_cell',
-                'desc': cell['source']
+                'desc': cell.get('source', 'Code Cell')
             }
         else:
             return {

--- a/lib/NarrativeService/NarrativeServiceImpl.py
+++ b/lib/NarrativeService/NarrativeServiceImpl.py
@@ -27,9 +27,9 @@ class NarrativeService:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.3.3"
+    VERSION = "0.4.0"
     GIT_URL = "git@github.com:charleshtrenholm/NarrativeService.git"
-    GIT_COMMIT_HASH = "c41e7d2f4a4be8b28742c743b5c512f7fb122cd5"
+    GIT_COMMIT_HASH = "ddadb2660e5c164703b2ec7b8f17a6a9ea3bef4c"
 
     #BEGIN_CLASS_HEADER
     def _nm(self, ctx):
@@ -855,52 +855,45 @@ class NarrativeService:
         """
         Intended to return data of previous versions of a given narrative in the same format returned from Search.
         Formats a call to workspace service to fit the appropriate schema that is intended for use in UI displays
-        in the narrative navigator.
+        in the narrative navigator. Raises error is "narrative_upa" param is not in specified <workspace_id/obj_id/version> format. 
+        Note that this method is currently to support the UI only, and does not return the full result of a search call,
+        and the following fields are omitted: boolean copied, boolean is_narratorial, boolean is_temporary, string obj_name, string obj_type_module,
+        string obj_type_version, list<string> tags.
         :param params: instance of type "SearchDocNarrativeParams"
            (narrative_upa - UPA of the narrative to be requested in search
            doc format.) -> structure: parameter "narrative_upa" of String
         :returns: instance of type "SearchDocResult" (access_group - A
            numeric ID which corresponds to the ownership group. cells - A
-           list of each cell's metadata within a given narrative. copied -
-           Indicates whether this narrative is a copy. creation_date - The
-           date this narrative was created. creator - The username of the
-           creator of a given narrative. data_objects - A list of each data
-           object used in a given narrative. is_narratorial - Whether or not
-           the doc item is narratorial. is_public - Whether or not a given
-           narrative is publicly shared. is_temporary - Whether or not a
-           given narrative exists permanently. modified_at - The date a given
-           narrative was last updated according to the version provided in
-           the UPA param. narrative_title - The title of a given narrative.
-           obj_id - The id of a given narrative obj_name - The name of a
-           given narrative obj_type_module - obj_type_version - owner - The
-           username of the current owner of a given narrative. shared_users -
-           A list of users who are allowed access to a given narrative. tags
-           - A list of all tagged versions of a given narrative ??? timestamp
-           - The time that a given narrative was last saved, regardless of
-           version. total_cells - The total number of cells in a given
-           narrative. version - The version of the narrative requested) ->
-           structure: parameter "access_group" of Long, parameter "cells" of
-           list of type "DocCell" (desc - a brief description of the
-           narrative cell. cell_type - the type of cell. count - the number
-           of instances this cell appears within a given narrative.) ->
-           structure: parameter "desc" of String, parameter "cell_type" of
-           String, parameter "count" of Long, parameter "copied" of type
-           "boolean" (@range [0,1]), parameter "creation_date" of String,
+           list of each cell's metadata within a given narrative.
+           creation_date - The date this narrative was created (ISO 8601).
+           creator - The username of the creator of a given narrative.
+           data_objects - A list of each data object used in a given
+           narrative. is_public - Whether or not a given narrative is
+           publicly shared. modified_at - The date a given narrative was last
+           updated according to the version provided in the UPA param (ms
+           since epoch). narrative_title - The title of a given narrative.
+           obj_id - The id of a given narrative shared_users - A list of
+           users who are allowed access to a given narrative. timestamp - The
+           time that a given narrative was last saved, regardless of version.
+           total_cells - The total number of cells in a given narrative.
+           version - The version of the narrative requested) -> structure:
+           parameter "access_group" of Long, parameter "cells" of list of
+           type "DocCell" (desc - a brief description of the narrative cell.
+           cell_type - the type of cell. Can be of type 'markdown', 'widget',
+           'data', 'kbase_app', 'code_cell', or '' if type is not
+           determined.) -> structure: parameter "desc" of String, parameter
+           "cell_type" of String, parameter "creation_date" of String,
            parameter "creator" of String, parameter "data_objects" of list of
            type "DocDataObject" (name - The name of the data object. obj_type
            - The type of data object. readableType - The data object type in
            a human readable format for displays.) -> structure: parameter
            "name" of String, parameter "obj_type" of String, parameter
-           "readableType" of String, parameter "is_narratorial" of type
-           "boolean" (@range [0,1]), parameter "is_public" of type "boolean"
-           (@range [0,1]), parameter "is_temporary" of type "boolean" (@range
-           [0,1]), parameter "modified_at" of Long, parameter
+           "readableType" of String, parameter "is_public" of type "boolean"
+           (@range [0,1]), parameter "modified_at" of Long, parameter
            "narrative_title" of String, parameter "obj_id" of Long, parameter
-           "obj_name" of String, parameter "obj_type_module" of String,
-           parameter "obj_type_version" of String, parameter "owner" of
-           String, parameter "shared_users" of list of String, parameter
-           "tags" of list of String, parameter "timestamp" of Long, parameter
-           "total_cells" of Long, parameter "version" of Long
+           "owner" of String, parameter "shared_users" of list of String,
+           parameter "timestamp" of Long, parameter "total_cells" of Long,
+           parameter "version" of Long
         """
         # ctx is the context object
         # return variables are: result

--- a/lib/NarrativeService/NarrativeServiceImpl.py
+++ b/lib/NarrativeService/NarrativeServiceImpl.py
@@ -908,8 +908,8 @@ class NarrativeService:
         try:
             ws_id = int(params['narrative_upa'].split('/')[0])
         except ValueError as e:
-            raise ValueError('Incorrect upa format: required format is <worspace_id>/<object_id>/<version>')
-        restult = self._nm(ctx).get_narrative_doc(ws_id, params['narrative_upa'])
+            raise ValueError('Incorrect upa format: required format is <workspace_id>/<object_id>/<version>')
+        result = self._nm(ctx).get_narrative_doc(ws_id, params['narrative_upa'])
         #END get_narrative_doc
 
         # At some point might do deeper type checking...

--- a/lib/NarrativeService/NarrativeServiceImpl.py
+++ b/lib/NarrativeService/NarrativeServiceImpl.py
@@ -27,9 +27,9 @@ class NarrativeService:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.3.2"
-    GIT_URL = "git@github.com:kbaseapps/NarrativeService.git"
-    GIT_COMMIT_HASH = "8d3dee255ebcac308a221a0a3cb1a2e9cfde18bd"
+    VERSION = "0.3.3"
+    GIT_URL = "git@github.com:charleshtrenholm/NarrativeService.git"
+    GIT_COMMIT_HASH = "c41e7d2f4a4be8b28742c743b5c512f7fb122cd5"
 
     #BEGIN_CLASS_HEADER
     def _nm(self, ctx):
@@ -847,6 +847,74 @@ class NarrativeService:
         # At some point might do deeper type checking...
         if not isinstance(result, dict):
             raise ValueError('Method rename_narrative return value ' +
+                             'result is not type dict as required.')
+        # return the results
+        return [result]
+
+    def get_narrative_doc(self, ctx, params):
+        """
+        Intended to return data of previous versions of a given narrative in the same format returned from Search.
+        Formats a call to workspace service to fit the appropriate schema that is intended for use in UI displays
+        in the narrative navigator.
+        :param params: instance of type "SearchDocNarrativeParams"
+           (narrative_upa - UPA of the narrative to be requested in search
+           doc format.) -> structure: parameter "narrative_upa" of String
+        :returns: instance of type "SearchDocResult" (access_group - A
+           numeric ID which corresponds to the ownership group. cells - A
+           list of each cell's metadata within a given narrative. copied -
+           Indicates whether this narrative is a copy. creation_date - The
+           date this narrative was created. creator - The username of the
+           creator of a given narrative. data_objects - A list of each data
+           object used in a given narrative. is_narratorial - Whether or not
+           the doc item is narratorial. is_public - Whether or not a given
+           narrative is publicly shared. is_temporary - Whether or not a
+           given narrative exists permanently. modified_at - The date a given
+           narrative was last updated according to the version provided in
+           the UPA param. narrative_title - The title of a given narrative.
+           obj_id - The id of a given narrative obj_name - The name of a
+           given narrative obj_type_module - obj_type_version - owner - The
+           username of the current owner of a given narrative. shared_users -
+           A list of users who are allowed access to a given narrative. tags
+           - A list of all tagged versions of a given narrative ??? timestamp
+           - The time that a given narrative was last saved, regardless of
+           version. total_cells - The total number of cells in a given
+           narrative. version - The version of the narrative requested) ->
+           structure: parameter "access_group" of Long, parameter "cells" of
+           list of type "DocCell" (desc - a brief description of the
+           narrative cell. cell_type - the type of cell. count - the number
+           of instances this cell appears within a given narrative.) ->
+           structure: parameter "desc" of String, parameter "cell_type" of
+           String, parameter "count" of Long, parameter "copied" of type
+           "boolean" (@range [0,1]), parameter "creation_date" of String,
+           parameter "creator" of String, parameter "data_objects" of list of
+           type "DocDataObject" (name - The name of the data object. obj_type
+           - The type of data object. readableType - The data object type in
+           a human readable format for displays.) -> structure: parameter
+           "name" of String, parameter "obj_type" of String, parameter
+           "readableType" of String, parameter "is_narratorial" of type
+           "boolean" (@range [0,1]), parameter "is_public" of type "boolean"
+           (@range [0,1]), parameter "is_temporary" of type "boolean" (@range
+           [0,1]), parameter "modified_at" of Long, parameter
+           "narrative_title" of String, parameter "obj_id" of Long, parameter
+           "obj_name" of String, parameter "obj_type_module" of String,
+           parameter "obj_type_version" of String, parameter "owner" of
+           String, parameter "shared_users" of list of String, parameter
+           "tags" of list of String, parameter "timestamp" of Long, parameter
+           "total_cells" of Long, parameter "version" of Long
+        """
+        # ctx is the context object
+        # return variables are: result
+        #BEGIN get_narrative_doc
+        try:
+            ws_id = int(params['narrative_upa'].split('/')[0])
+        except ValueError as e:
+            raise ValueError('Incorrect upa format: required format is <worspace_id>/<object_id>/<version>')
+        restult = self._nm(ctx).get_narrative_doc(ws_id, params['narrative_upa'])
+        #END get_narrative_doc
+
+        # At some point might do deeper type checking...
+        if not isinstance(result, dict):
+            raise ValueError('Method get_narrative_doc return value ' +
                              'result is not type dict as required.')
         # return the results
         return [result]

--- a/lib/NarrativeService/NarrativeServiceImpl.py
+++ b/lib/NarrativeService/NarrativeServiceImpl.py
@@ -898,11 +898,7 @@ class NarrativeService:
         # ctx is the context object
         # return variables are: result
         #BEGIN get_narrative_doc
-        try:
-            ws_id = int(params['narrative_upa'].split('/')[0])
-        except ValueError as e:
-            raise ValueError('Incorrect upa format: required format is <workspace_id>/<object_id>/<version>')
-        result = self._nm(ctx).get_narrative_doc(ws_id, params['narrative_upa'])
+        result = self._nm(ctx).get_narrative_doc(params['narrative_upa'])
         #END get_narrative_doc
 
         # At some point might do deeper type checking...

--- a/lib/NarrativeService/NarrativeServiceServer.py
+++ b/lib/NarrativeService/NarrativeServiceServer.py
@@ -402,6 +402,10 @@ class Application(object):
                              name='NarrativeService.rename_narrative',
                              types=[dict])
         self.method_authentication['NarrativeService.rename_narrative'] = 'required'  # noqa
+        self.rpc_service.add(impl_NarrativeService.get_narrative_doc,
+                             name='NarrativeService.get_narrative_doc',
+                             types=[dict])
+        self.method_authentication['NarrativeService.get_narrative_doc'] = 'required'  # noqa
         self.rpc_service.add(impl_NarrativeService.status,
                              name='NarrativeService.status',
                              types=[dict])

--- a/test/NarrativeManager_test.py
+++ b/test/NarrativeManager_test.py
@@ -37,3 +37,29 @@ class NarrativeManagerTestCase(unittest.TestCase):
         nm.rename_narrative(narrative_ref, new_name, version)
 
         self.assertEqual(self.workspace_client.get_objects2({"objects": [{"ref": narrative_ref}]})["data"][0]["data"]["metadata"]["name"], new_name)
+
+
+    def test_get_narrative_doc(self):
+        # set up narrative
+        narrative_ref = self.workspace_client.make_fake_narrative("Doc Format Test", self.user_id)
+        nm = NarrativeManager(self.config, self.user_id, self.set_api_client, self.data_palette_client, self.workspace_client)
+
+        # get ws_id
+        ws_id = int(narrative_ref.split('/')[0])
+        # add version number
+        full_upa = narrative_ref + '/1'
+
+        doc = nm.get_narrative_doc(ws_id, full_upa)
+
+        self.assertEqual(doc['access_group'], ws_id)
+        self.assertEqual(doc['cells'], [])
+        self.assertEqual(doc['total_cells'], 0)
+        self.assertFalse(doc['is_public'])
+
+        # test data object format
+        self.assertEqual(len(doc['data_objects']), 10)
+        self.assertEqual(doc['data_objects'][0], {'name': 'Object_1-1', 'obj_type': 'KBaseNarrative.Narrative-4.0'})
+
+        self.assertEqual(doc['timestamp'], 0)
+        self.assertEqual(doc['creation_date'], '1970-01-01T00:00:00+0000')
+

--- a/test/NarrativeManager_test.py
+++ b/test/NarrativeManager_test.py
@@ -49,7 +49,7 @@ class NarrativeManagerTestCase(unittest.TestCase):
         # add version number
         full_upa = narrative_ref + '/1'
 
-        doc = nm.get_narrative_doc(ws_id, full_upa)
+        doc = nm.get_narrative_doc(full_upa)
 
         self.assertEqual(doc['access_group'], ws_id)
         self.assertEqual(doc['cells'], [])
@@ -62,4 +62,14 @@ class NarrativeManagerTestCase(unittest.TestCase):
 
         self.assertEqual(doc['timestamp'], 0)
         self.assertEqual(doc['creation_date'], '1970-01-01T00:00:00+0000')
+
+        # test that poorly formatted upa is handled correctly
+        with self.assertRaises(ValueError) as err:
+            nm.get_narrative_doc(narrative_ref)
+        self.assertIn('Incorrect upa format: required format is <workspace_id>/<object_id>/<version>', str(err.exception))
+
+        # ensure that proper not found message is raised
+        with self.assertRaises(ValueError) as err:
+            nm.get_narrative_doc('2000/2000/2000')
+        self.assertIn('Item with upa "2000/2000/2000" not found in workspace database.', str(err.exception))
 

--- a/test/workspace_mock.py
+++ b/test/workspace_mock.py
@@ -1,3 +1,5 @@
+from jsonrpcbase import ServerError
+
 class EmptyWorkspaceMock:
     def __init__(self, *args, **kwargs):
         self.user = "some_user"
@@ -189,6 +191,9 @@ class WorkspaceMock:
             if ws_id in self.internal_db and obj_id in self.internal_db[ws_id]["objects"]:
                 return_data["data"].append(self.internal_db[ws_id]["objects"][obj_id])
                 return_data["paths"].append(ref)
+            else:
+                # mock error from missing workspace or object
+                raise ServerError('JSONRPCError: -32500')
         # for testing get_narrative_doc
         return_data['epoch'] = 0
         return_data['created'] = '1970-01-01T00:00:00+0000'

--- a/test/workspace_mock.py
+++ b/test/workspace_mock.py
@@ -189,6 +189,11 @@ class WorkspaceMock:
             if ws_id in self.internal_db and obj_id in self.internal_db[ws_id]["objects"]:
                 return_data["data"].append(self.internal_db[ws_id]["objects"][obj_id])
                 return_data["paths"].append(ref)
+        # for testing get_narrative_doc
+        return_data['epoch'] = 0
+        return_data['created'] = '1970-01-01T00:00:00+0000'
+        return_data['orig_wsid'] = ws_id
+        return_data['creator'] = 'some_user'
         return return_data
 
     def get_permissions_mass(self, params):


### PR DESCRIPTION
This creates a `get_narrative_doc` method that formats data in the same schema as a search API result. This is needed to return proper data to the UI for prior versions of a narrative as the search API does not index old versions.