### PR TITLE
Fix get narrative doc worksheets

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 
-## v0.3.5
+## v0.5.2
 * Fix `get_narrative_doc` method for fetching legacy narratives with `worksheets` as a key
 
 ## v0.3.4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 
+## v0.3.5
+* Fix `get_narrative_doc` method for fetching legacy narratives with `worksheets` as a key
+
 ## v0.3.4
 * Add `get_narrative_doc` method that returns narrative data in the same format as the Search API results
 ## v0.3.3

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.5.1
+    0.5.2
 
 owners:
     [wjriehl, tgu2]

--- a/lib/NarrativeService/NarrativeManager.py
+++ b/lib/NarrativeService/NarrativeManager.py
@@ -45,8 +45,8 @@ class NarrativeManager:
         shared_users, is_public = self._fmt_doc_permissions(permissions)
 
         # get cells (checking for older narratives)
-        if 'worksheets' in obj_data:
-            cells = obj_data['worksheets'][0]['cells']
+        if 'worksheets' in obj_data['data']:
+            cells = obj_data['data']['worksheets'][0]['cells']
         else:
             cells = obj_data['data']['cells']
 


### PR DESCRIPTION
The `get_narrative_doc` method would fail on legacy KBase objects with a `"worksheets"` key. This was because the code was looking for the worksheets key in the wrong area of the response JSON. This fix adds the correct location for a worksheets object (inside of `result['data'][0]['data']` instead of at the same level) and prevents and unexpected `KeyError: "cells"`